### PR TITLE
import global css easily from components

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -23,6 +23,12 @@
         "styles/mixins.scss",
         "styles/variables.scss"
       ],
+      "stylePreprocessorOptions": {
+        "includePaths": [
+          ".",
+          "./styles"
+        ]
+      },
       "scripts": [],
       "environmentSource": "environments/environment.ts",
       "environments": {


### PR DESCRIPTION
fixes #29 
While importing global css styles we have to define the relative path everytime. This makes it easy with
`@import 'variables.scss';`

or 
`@import 'styles/variables.scss';`

Ref : https://scotch.io/tutorials/angular-shortcut-to-importing-styles-files-in-components