### PR TITLE
Add normalize.css to reset browers' default stylesheet

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -19,9 +19,8 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
-        "styles/base.scss",
-        "styles/mixins.scss",
-        "styles/variables.scss"
+        "../node_modules/normalize.css/normalize.css",
+        "styles/base.scss"
       ],
       "stylePreprocessorOptions": {
         "includePaths": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
     "core-js": "^2.4.1",
+    "normalize.css": "^8.0.0",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.19"
   },


### PR DESCRIPTION
Source:
[normalize.css](https://github.com/necolas/normalize.css/)

Note: `npm install` is mandatory after applying changes from this PR