### PR TITLE
[WIP] GSoC Idea - Add 500 error page

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
     "core-js": "^2.4.1",
-    "ngx-twitter-timeline": "^0.1.4",
+    "ngx-twitter-timeline": "0.1.4",
     "normalize.css": "^8.0.0",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.19"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
     "tslint": "^5.9.1",
-    "typescript": "^2.5.3"
+    "typescript": ">=2.4.2 <2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
     "tslint": "^5.9.1",
-    "typescript": ">=2.4.2 <2.7.0"
+    "typescript": "^3.3.3333"
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -26,6 +26,7 @@ import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { ProfileComponent } from './components/profile/profile.component';
 import { OurTeamComponent } from './components/our-team/our-team.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
+import { InternalServerComponent } from './components/error-pages/internal-server/internal-server.component';
 
 const routes: Routes = [
   {
@@ -123,10 +124,15 @@ const routes: Routes = [
     component: NotFoundComponent
   },
   {
+    path: '500',
+    component: InternalServerComponent
+  },
+  {
     path: '**',
     redirectTo: '/404',
     pathMatch: 'full'
-  }
+  },
+
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,3 @@
-import { HttpErrorInterceptor } from './interceptors/http-error-interceptor';
 // Import Modules
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
@@ -62,6 +61,9 @@ import { RulesComponent } from './components/home/rules/rules.component';
 import { TestimonialsComponent } from './components/home/testimonials/testimonials.component';
 import { FeaturedChallengesComponent } from './components/home/featured-challenges/featured-challenges.component';
 import { InternalServerComponent } from './components/error-pages/internal-server/internal-server.component';
+
+// Interceptors
+import { HttpErrorInterceptor } from './interceptors/http-error-interceptor';
 
 @NgModule({
   declarations: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,8 @@
+import { HttpErrorInterceptor } from './interceptors/http-error-interceptor';
 // Import Modules
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 // Import serivces
 import { AuthService } from './services/auth.service';
@@ -10,7 +11,7 @@ import { ApiService } from './services/api.service';
 import { GlobalService } from './services/global.service';
 import { ChallengeService } from './services/challenge.service';
 import { EndpointsService } from './services/endpoints.service';
-
+import { ErrorHandlerService } from './services/error-handler.service';
 
 // Import Components
 import { AppComponent } from './app.component';
@@ -60,6 +61,7 @@ import { PartnersComponent } from './components/home/partners/partners.component
 import { RulesComponent } from './components/home/rules/rules.component';
 import { TestimonialsComponent } from './components/home/testimonials/testimonials.component';
 import { FeaturedChallengesComponent } from './components/home/featured-challenges/featured-challenges.component';
+import { InternalServerComponent } from './components/error-pages/internal-server/internal-server.component';
 
 @NgModule({
   declarations: [
@@ -107,7 +109,8 @@ import { FeaturedChallengesComponent } from './components/home/featured-challeng
     PartnersComponent,
     RulesComponent,
     TestimonialsComponent,
-    FeaturedChallengesComponent
+    FeaturedChallengesComponent,
+    InternalServerComponent
   ],
   imports: [
     BrowserModule,
@@ -121,7 +124,13 @@ import { FeaturedChallengesComponent } from './components/home/featured-challeng
     ApiService,
     GlobalService,
     ChallengeService,
-    EndpointsService
+    EndpointsService,
+    ErrorHandlerService,
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HttpErrorInterceptor,
+      multi: true,
+    },
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/error-pages/internal-server/internal-server.component.html
+++ b/src/app/components/error-pages/internal-server/internal-server.component.html
@@ -1,0 +1,3 @@
+<p>
+  internal-server works!
+</p>

--- a/src/app/components/error-pages/internal-server/internal-server.component.html
+++ b/src/app/components/error-pages/internal-server/internal-server.component.html
@@ -1,3 +1,20 @@
 <p>
   internal-server works!
 </p>
+<div class="not-found-container">
+  <div id="clouds">
+    <div class="cloud x1"></div>
+    <div class="cloud x1_5"></div>
+    <div class="cloud x2"></div>
+    <div class="cloud x3"></div>
+    <div class="cloud x4"></div>
+    <div class="cloud x5"></div>
+  </div>
+  <div class='c'>
+    <div class='_404'>500</div>
+    <hr>
+    <div class='_1'>Unexpected error :(</div>
+    <div class='_2 link'> <a href='#'>Go back to homepage and try again</a></div>
+  </div>
+  <div class='link' ></div>
+  </div>

--- a/src/app/components/error-pages/internal-server/internal-server.component.scss
+++ b/src/app/components/error-pages/internal-server/internal-server.component.scss
@@ -1,0 +1,214 @@
+@import './variables.scss';
+@import './mixins.scss';
+
+.not-found-container {
+	background: $red-light;
+    color:white;
+    overflow: hidden;
+    position:absolute;
+    top:0;
+    width:100%;
+    left:0;
+    height:100%;
+    font-weight: $fw-light;
+    .link {
+    	position: absolute;
+        bottom: 0;
+        text-align: center;
+        left: 0;
+        margin: 20px;
+        width: 100%;
+        a {
+        	color: white;
+        	font-weight:$fw-regular;
+        	&:hover {
+        		color: black;
+        	}
+        }
+    }
+    .c{
+        text-align: center;
+        display: block;
+        position: relative;
+        width:80%;
+        margin:100px auto;
+    }
+    ._404{
+        font-size: 220px;
+        position: relative;
+        display: inline-block;
+        z-index: 2;
+        height: 250px;
+        letter-spacing: 15px;
+    }
+    ._1{
+        text-align:center;
+        display:block;
+        position:relative;
+        letter-spacing: 12px;
+        font-size: 4em;
+        line-height: 80%;
+        margin:20px;
+    }
+    ._2{
+        text-align:center;
+        display:block;
+        position: relative;
+        font-size: 20px;
+        margin:20px;
+    }
+    .text{
+        font-size: 70px;
+        text-align: center;
+        position: relative;
+        display: inline-block;
+        margin: 19px 0px 0px 0px;
+        /* top: 256.301px; */
+        z-index: 3;
+        width: 100%;
+        line-height: 1.2em;
+        display: inline-block;
+    }
+    .right{
+        float:right;
+        width:60%;
+    }
+
+    hr{
+        padding: 0;
+        border: none;
+        border-top: 5px solid white;
+        color: white;
+        text-align: center;
+        margin: 0px auto;
+        width: 420px;
+        height:10px;
+        z-index: -10;
+    }
+
+    .cloud {
+        width: 350px; height: 120px;
+        background: white;
+
+
+        border-radius: 100px;
+        -webkit-border-radius: 100px;
+        -moz-border-radius: 100px;
+
+        position: absolute;
+        margin: 120px auto 20px;
+        z-index:1;
+        transition: ease 1s;
+    }
+
+    .cloud:after, .cloud:before {
+        content: '';
+        position: absolute;
+        background: #FFF;
+        z-index: -1
+    }
+
+    .cloud:after {
+        width: 100px; height: 100px;
+        top: -50px; left: 50px;
+
+        border-radius: 100px;
+        -webkit-border-radius: 100px;
+        -moz-border-radius: 100px;
+    }
+
+    .cloud:before {
+        width: 180px; height: 180px;
+        top: -90px; right: 50px;
+
+        border-radius: 200px;
+        -webkit-border-radius: 200px;
+        -moz-border-radius: 200px;
+    }
+
+    .x1 {
+        top:-50px;
+        left:100px;
+        -webkit-transform: scale(0.3);
+        -moz-transform: scale(0.3);
+        transform: scale(0.3);
+        opacity: 0.9;
+        -webkit-animation: moveclouds 15s linear infinite;
+        -moz-animation: moveclouds 15s linear infinite;
+        -o-animation: moveclouds 15s linear infinite;
+    }
+
+    .x1_5{
+        top:-80px;
+        left:250px;
+        -webkit-transform: scale(0.3);
+        -moz-transform: scale(0.3);
+        transform: scale(0.3);
+        -webkit-animation: moveclouds 17s linear infinite;
+        -moz-animation: moveclouds 17s linear infinite;
+        -o-animation: moveclouds 17s linear infinite;
+    }
+
+    .x2 {
+        left: 250px;
+        top:30px;
+        -webkit-transform: scale(0.6);
+        -moz-transform: scale(0.6);
+        transform: scale(0.6);
+        opacity: 0.6;
+        -webkit-animation: moveclouds 25s linear infinite;
+        -moz-animation: moveclouds 25s linear infinite;
+        -o-animation: moveclouds 25s linear infinite;
+    }
+
+    .x3 {
+        left: 250px; bottom: -70px;
+
+        -webkit-transform: scale(0.6);
+        -moz-transform: scale(0.6);
+        transform: scale(0.6);
+        opacity: 0.8;
+
+        -webkit-animation: moveclouds 25s linear infinite;
+        -moz-animation: moveclouds 25s linear infinite;
+        -o-animation: moveclouds 25s linear infinite;
+    }
+
+    .x4 {
+        left: 470px; botttom: 20px;
+
+        -webkit-transform: scale(0.75);
+        -moz-transform: scale(0.75);
+        transform: scale(0.75);
+        opacity: 0.75;
+
+        -webkit-animation: moveclouds 18s linear infinite;
+        -moz-animation: moveclouds 18s linear infinite;
+        -o-animation: moveclouds 18s linear infinite;
+    }
+
+    .x5 {
+        left: 200px; top: 300px;
+
+        -webkit-transform: scale(0.5);
+        -moz-transform: scale(0.5);
+        transform: scale(0.5);
+        opacity: 0.8;
+
+        -webkit-animation: moveclouds 20s linear infinite;
+        -moz-animation: moveclouds 20s linear infinite;
+        -o-animation: moveclouds 20s linear infinite;
+    }
+    @include keyframes(moveclouds) {
+    	0% {margin-left: 1000px;}
+        100% {margin-left: -1000px;}
+    }
+}
+
+@include screen-small {
+	.not-found-container {
+		._404{
+			font-size: 150px;
+		}
+	}
+}

--- a/src/app/components/error-pages/internal-server/internal-server.component.spec.ts
+++ b/src/app/components/error-pages/internal-server/internal-server.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InternalServerComponent } from './internal-server.component';
+
+describe('InternalServerComponent', () => {
+  let component: InternalServerComponent;
+  let fixture: ComponentFixture<InternalServerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ InternalServerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InternalServerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/error-pages/internal-server/internal-server.component.ts
+++ b/src/app/components/error-pages/internal-server/internal-server.component.ts
@@ -6,10 +6,9 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./internal-server.component.scss']
 })
 export class InternalServerComponent implements OnInit {
-  public errorMessage: string = '500 SERVER ERROR, CONTACT ADMINISTRATOR!!!!';
+
   constructor() { }
 
-  ngOnInit() {
-  }
+  ngOnInit() { }
 
 }

--- a/src/app/components/error-pages/internal-server/internal-server.component.ts
+++ b/src/app/components/error-pages/internal-server/internal-server.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-internal-server',
+  templateUrl: './internal-server.component.html',
+  styleUrls: ['./internal-server.component.scss']
+})
+export class InternalServerComponent implements OnInit {
+  public errorMessage: string = '500 SERVER ERROR, CONTACT ADMINISTRATOR!!!!';
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/interceptors/http-error-interceptor.ts
+++ b/src/app/interceptors/http-error-interceptor.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpResponse,
+  HttpErrorResponse,
+} from '@angular/common/http';
+
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/operator/do';
+import { ErrorHandlerService } from './../services/error-handler.service';
+
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+
+  constructor(private errorHandler: ErrorHandlerService) {
+  }
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    return next.handle(request).do((event: HttpEvent<any>) => {console.log('event -> ' + JSON.stringify(event));}, (err: any) => {
+      if (err instanceof HttpErrorResponse) {
+        this.errorHandler.handleError(err);
+        console.log(JSON.stringify(err) + ' is error..');
+      }
+    });
+  }
+}

--- a/src/app/interceptors/http-error-interceptor.ts
+++ b/src/app/interceptors/http-error-interceptor.ts
@@ -21,10 +21,9 @@ export class HttpErrorInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
 
-    return next.handle(request).do((event: HttpEvent<any>) => {console.log('event -> ' + JSON.stringify(event));}, (err: any) => {
+    return next.handle(request).do((event: HttpEvent<any>) => { }, (err: any) => {
       if (err instanceof HttpErrorResponse) {
         this.errorHandler.handleError(err);
-        console.log(JSON.stringify(err) + ' is error..');
       }
     });
   }

--- a/src/app/services/error-handler.service.spec.ts
+++ b/src/app/services/error-handler.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ErrorHandlerService } from './error-handler.service';
+
+describe('ErrorHandlerService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ErrorHandlerService]
+    });
+  });
+
+  it('should be created', inject([ErrorHandlerService], (service: ErrorHandlerService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -4,25 +4,20 @@ import { HttpErrorResponse } from '@angular/common/http';
 
 @Injectable()
 export class ErrorHandlerService {
-  public errorMessage: string = '';
 
   constructor(private router: Router) { }
 
-  public handleError(error: HttpErrorResponse){
-    if(error.status === 500) {
+  public handleError(error: HttpErrorResponse) {
+    if ( error.status === 500) {
       this.handle500Error(error);
     }
     // TODO: Handle other errors : 404 or unknown status
   }
 
-  private handle500Error(error: HttpErrorResponse){
-    this.createErrorMessage(error);
+  private handle500Error(error: HttpErrorResponse) {
     this.router.navigate(['/500']);
-  }
-
-  private createErrorMessage(error: HttpErrorResponse){
-    this.errorMessage = error.error ? error.error : error.statusText;
-    console.log('errorMessage => ' + this.errorMessage);
+    // TODO: We can extract the error message or text and send to 500 page
+    // using this line : `error.error ? error.error : error.statusText`
   }
 
 }

--- a/src/app/services/error-handler.service.ts
+++ b/src/app/services/error-handler.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Injectable()
+export class ErrorHandlerService {
+  public errorMessage: string = '';
+
+  constructor(private router: Router) { }
+
+  public handleError(error: HttpErrorResponse){
+    if(error.status === 500) {
+      this.handle500Error(error);
+    }
+    // TODO: Handle other errors : 404 or unknown status
+  }
+
+  private handle500Error(error: HttpErrorResponse){
+    this.createErrorMessage(error);
+    this.router.navigate(['/500']);
+  }
+
+  private createErrorMessage(error: HttpErrorResponse){
+    this.errorMessage = error.error ? error.error : error.statusText;
+    console.log('errorMessage => ' + this.errorMessage);
+  }
+
+}


### PR DESCRIPTION
Fixes # [GSoC Idea - Add 500 error page](https://github.com/Cloud-CV/GSoC-Ideas/issues/23)


#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- if there is any HTTP request is sent from the Angular application and response it 500 status code, it will redirect to 500 page (InternalServerComponent)

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-XXX-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
-
![500](https://user-images.githubusercontent.com/5774448/54435333-401e5500-4756-11e9-9742-dad9116dd11d.png)



TODOs / Future work :

- [ ]  For `error-page` a separate module can be created and imported to app module for lazy loading.
- [ ]  error-page uses a service that redirect to 500 page , similar things can be done for 404, 400 or other status code.  
- [ ]  move the not-found component in error-page folder.
- [ ]  services related to errors and error handler can be rearranged in one folder.
- [ ] Write testcase for the changes

