### PR TITLE
Add a feature corresponding to each submission for challenge host to toggle the submission visibility

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -71,6 +71,8 @@ import { EditphasemodalComponent } from './components/challenge/challengephases/
 import {
   ChallengeviewallsubmissionsComponent
 } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [
@@ -135,7 +137,9 @@ import {
     OwlDateTimeModule,
     OwlNativeDateTimeModule,
     MatSelectModule,
-    MatChipsModule
+    MatChipsModule,
+    MatMenuModule,
+    MatIconModule
   ],
   providers: [
     AuthService,

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
@@ -107,11 +107,11 @@
                   <td>
                     <a [matMenuTriggerFor]="settingsmenu"><i class="fa fa-gear"></i></a>
                     <mat-menu #settingsmenu="matMenu">
-                        <button (click)="confirmSubmissionVisibility(key, key.is_public)" mat-menu-item>
-                          <mat-icon class="green-text">{{key.submissionVisibilityIcon}}</mat-icon>
-                          <span>{{key.submissionVisibilityText}}</span>
-                        </button>
-                      </mat-menu>
+                      <button *ngIf="key.status == 'finished'" (click)="confirmSubmissionVisibility(key, key.is_public)" mat-menu-item>
+                        <mat-icon class="green-text">{{key.submissionVisibilityIcon}}</mat-icon>
+                        <span>{{key.submissionVisibilityText}}</span>
+                      </button>
+                    </mat-menu>
                   </td>
                 </tr>
               </tbody>

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
@@ -107,7 +107,7 @@
                   <td>
                     <a [matMenuTriggerFor]="settingsmenu"><i class="fa fa-gear"></i></a>
                     <mat-menu #settingsmenu="matMenu">
-                        <button (click)="changeSubmissionVisibility(key, key.is_public)" mat-menu-item>
+                        <button (click)="confirmSubmissionVisibility(key, key.is_public)" mat-menu-item>
                           <mat-icon class="green-text">{{key.submissionVisibilityIcon}}</mat-icon>
                           <span>{{key.submissionVisibilityText}}</span>
                         </button>

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.html
@@ -57,6 +57,7 @@
                   <th data-field="file">Metadata File</th>
                   <th *ngIf="selectedPhase['leaderboard_public']"
                     data-field="file">Show on Leaderboard</th>
+                  <th data-field="settings">Submission Settings</th>
                 </tr>
               </thead>
               <tbody>
@@ -101,6 +102,16 @@
                       class="cbx hidden" />
                     <label for="isPublic{{ key.id }}" class="cbx-label"></label>
                     <span *ngIf="key.status !== 'finished'"> N/A </span>
+                  </td>
+
+                  <td>
+                    <a [matMenuTriggerFor]="settingsmenu"><i class="fa fa-gear"></i></a>
+                    <mat-menu #settingsmenu="matMenu">
+                        <button (click)="changeSubmissionVisibility(key, key.is_public)" mat-menu-item>
+                          <mat-icon class="green-text">{{key.submissionVisibilityIcon}}</mat-icon>
+                          <span>{{key.submissionVisibilityText}}</span>
+                        </button>
+                      </mat-menu>
                   </td>
                 </tr>
               </tbody>

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.spec.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.spec.ts
@@ -10,6 +10,8 @@ import { EndpointsService } from '../../../services/endpoints.service';
 import { WindowService } from '../../../services/window.service';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
 
 describe('ChallengeviewallsubmissionsComponent', () => {
   let component: ChallengeviewallsubmissionsComponent;
@@ -20,7 +22,7 @@ describe('ChallengeviewallsubmissionsComponent', () => {
       declarations: [ ChallengeviewallsubmissionsComponent ],
       providers: [ ChallengeService, GlobalService, AuthService, ApiService,
         EndpointsService, WindowService ],
-      imports: [ HttpClientModule, RouterTestingModule ],
+      imports: [ HttpClientModule, RouterTestingModule, MatMenuModule, MatIconModule ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -105,9 +105,6 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
    */
   phaseSelectionType = 'selectBox';
 
-  SubmissionVisibilityIcon;
-  SubmissionVisibilityText;
-
   /**
    * Fields to be exported
    */
@@ -369,7 +366,7 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
           SELF.globalService.handleApiError(err);
         },
         () => {
-          console.log('Updated submission visibility', id);
+          console.log('Updated submission visibility', submission.id);
         }
       );
     }

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -105,6 +105,9 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
    */
   phaseSelectionType = 'selectBox';
 
+  SubmissionVisibilityIcon;
+  SubmissionVisibilityText;
+
   /**
    * Fields to be exported
    */
@@ -209,6 +212,15 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
     this.apiService.getUrl(API_PATH).subscribe(
       data => {
         SELF.submissions = data['results'];
+        for (let i = 0; i < SELF.submissions.length; i++) {
+          if (SELF.submissions[i].is_public) {
+            SELF.submissions[i].submissionVisibilityIcon = 'visibility';
+            SELF.submissions[i].submissionVisibilityText = 'Public';
+          } else {
+            SELF.submissions[i].submissionVisibilityIcon = 'visibility_off';
+            SELF.submissions[i].submissionVisibilityText = 'Private';
+          }
+        }
         SELF.paginationDetails.next = data.next;
         SELF.paginationDetails.previous = data.previous;
         SELF.paginationDetails.totalPage = Math.ceil(data.count / 100);
@@ -329,21 +341,27 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
 
   /**
    * Change Submission's leaderboard visibility API.
-   * @param id  Submission id
+   * @param submission  Selected submission
    * @param is_public  visibility boolean flag
    */
-  changeSubmissionVisibility(id, is_public) {
+  changeSubmissionVisibility(submission, is_public) {
     is_public = !is_public;
-    this.updateSubmissionVisibility(id);
-    if (this.challenge['id'] && this.selectedPhase && this.selectedPhase['id'] && id) {
-      const API_PATH = this.endpointsService.challengeSubmissionUpdateURL(this.challenge['id'], this.selectedPhase['id'], id);
+    this.updateSubmissionVisibility(submission.id);
+    if (this.challenge['id'] && this.selectedPhase && this.selectedPhase['id'] && submission.id) {
+      const API_PATH = this.endpointsService.challengeSubmissionUpdateURL(
+        this.challenge['id'], this.selectedPhase['id'], submission.id
+      );
       const SELF = this;
       const BODY = JSON.stringify({is_public: is_public});
       this.apiService.patchUrl(API_PATH, BODY).subscribe(
         () => {
           if (is_public) {
+            submission.submissionVisibilityIcon = 'visibility';
+            submission.submissionVisibilityText = 'Public';
             SELF.globalService.showToast('success', 'The submission is made public');
           } else {
+            submission.submissionVisibilityIcon = 'visibility_off';
+            submission.submissionVisibilityText = 'Private';
             SELF.globalService.showToast('success', 'The submission is made private');
           }
         },

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -215,15 +215,10 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       data => {
         SELF.submissions = data['results'];
         for (let i = 0; i < SELF.submissions.length; i++) {
-          (SELF.submissions[i].is_public) ?
-          (
-            SELF.submissions[i].submissionVisibilityIcon = 'visibility',
-            SELF.submissions[i].submissionVisibilityText = 'Public'
-          ) :
-          (
-            SELF.submissions[i].submissionVisibilityIcon = 'visibility_off',
-            SELF.submissions[i].submissionVisibilityText = 'Private'
-          );
+          SELF.submissions[i].submissionVisibilityIcon =
+            (SELF.submissions[i].is_public) ? 'visibility' : 'visibility_off';
+          SELF.submissions[i].submissionVisibilityText =
+            (SELF.submissions[i].is_public) ? 'Public' : 'Private';
         }
         SELF.paginationDetails.next = data.next;
         SELF.paginationDetails.previous = data.previous;
@@ -359,17 +354,10 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       const BODY = JSON.stringify({is_public: is_public});
       this.apiService.patchUrl(API_PATH, BODY).subscribe(
         () => {
-          (is_public) ?
-          (
-            submission.submissionVisibilityIcon = 'visibility',
-            submission.submissionVisibilityText = 'Public',
-            SELF.globalService.showToast('success', 'The submission is made public')
-          ) :
-          (
-            submission.submissionVisibilityIcon = 'visibility_off',
-            submission.submissionVisibilityText = 'Private',
-            SELF.globalService.showToast('success', 'The submission is made private')
-          );
+          submission.submissionVisibilityIcon = (is_public) ? 'visibility' : 'visibility_off';
+          submission.submissionVisibilityIcon = (is_public) ? 'Public' : 'Private';
+          const toastMessage = (is_public) ? 'The submission is made public' : 'The submission is made private';
+          SELF.globalService.showToast('success', toastMessage);
         },
         err => {
           SELF.globalService.handleApiError(err);

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -361,6 +361,7 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
             SELF.globalService.showToast('success', 'The submission is made public')
           ) :
           (
+            submission.submissionVisibilityIcon = 'visibility_off',
             submission.submissionVisibilityText = 'Private',
             SELF.globalService.showToast('success', 'The submission is made private')
           );

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -355,7 +355,7 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       this.apiService.patchUrl(API_PATH, BODY).subscribe(
         () => {
           submission.submissionVisibilityIcon = (is_public) ? 'visibility' : 'visibility_off';
-          submission.submissionVisibilityIcon = (is_public) ? 'Public' : 'Private';
+          submission.submissionVisibilityText = (is_public) ? 'Public' : 'Private';
           const toastMessage = (is_public) ? 'The submission is made public' : 'The submission is made private';
           SELF.globalService.showToast('success', toastMessage);
         },

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -120,6 +120,11 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
   paginationDetails: any = {};
 
   /**
+   * API call inside the modal
+   */
+  apiCall: any;
+
+  /**
    * Constructor.
    * @param route  ActivatedRoute Injection.
    * @param router  GlobalService Injection.
@@ -395,5 +400,30 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
         console.log('Fetched submission counts', challenge, phase);
       }
     );
+  }
+
+  /**
+   * Modal to confirm the change of submission visibility
+   * @param submission  Selected submission
+   * @param submissionVisibility current submission visibility
+   */
+  confirmSubmissionVisibility(submission, submissionVisibility) {
+    const SELF = this;
+    let toggleSubmissionVisibilityState;
+    (submissionVisibility) ?
+    (toggleSubmissionVisibilityState = 'private') :
+    (toggleSubmissionVisibilityState = 'public');
+
+    SELF.apiCall = () => {
+      SELF.changeSubmissionVisibility(submission, submissionVisibility);
+    };
+
+    const PARAMS = {
+      title: 'Make this submission ' + toggleSubmissionVisibilityState + '?',
+      confirm: 'Yes, I\'m sure',
+      deny: 'No',
+      confirmCallback: SELF.apiCall
+    };
+    SELF.globalService.showConfirm(PARAMS);
   }
 }

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -210,13 +210,15 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       data => {
         SELF.submissions = data['results'];
         for (let i = 0; i < SELF.submissions.length; i++) {
-          if (SELF.submissions[i].is_public) {
-            SELF.submissions[i].submissionVisibilityIcon = 'visibility';
-            SELF.submissions[i].submissionVisibilityText = 'Public';
-          } else {
-            SELF.submissions[i].submissionVisibilityIcon = 'visibility_off';
-            SELF.submissions[i].submissionVisibilityText = 'Private';
-          }
+          (SELF.submissions[i].is_public) ?
+          (
+            SELF.submissions[i].submissionVisibilityIcon = 'visibility',
+            SELF.submissions[i].submissionVisibilityText = 'Public'
+          ) :
+          (
+            SELF.submissions[i].submissionVisibilityIcon = 'visibility_off',
+            SELF.submissions[i].submissionVisibilityText = 'Private'
+          );
         }
         SELF.paginationDetails.next = data.next;
         SELF.paginationDetails.previous = data.previous;
@@ -352,22 +354,21 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
       const BODY = JSON.stringify({is_public: is_public});
       this.apiService.patchUrl(API_PATH, BODY).subscribe(
         () => {
-          if (is_public) {
-            submission.submissionVisibilityIcon = 'visibility';
-            submission.submissionVisibilityText = 'Public';
-            SELF.globalService.showToast('success', 'The submission is made public');
-          } else {
-            submission.submissionVisibilityIcon = 'visibility_off';
-            submission.submissionVisibilityText = 'Private';
-            SELF.globalService.showToast('success', 'The submission is made private');
-          }
+          (is_public) ?
+          (
+            submission.submissionVisibilityIcon = 'visibility',
+            submission.submissionVisibilityText = 'Public',
+            SELF.globalService.showToast('success', 'The submission is made public')
+          ) :
+          (
+            submission.submissionVisibilityText = 'Private',
+            SELF.globalService.showToast('success', 'The submission is made private')
+          );
         },
         err => {
           SELF.globalService.handleApiError(err);
         },
-        () => {
-          console.log('Updated submission visibility', submission.id);
-        }
+        () => {}
       );
     }
   }

--- a/src/app/components/utility/confirm/confirm.component.scss
+++ b/src/app/components/utility/confirm/confirm.component.scss
@@ -5,6 +5,9 @@
   z-index: 110;
   .confirm-card {
     z-index: 111;
+    .title {
+      margin: 0px;
+    }
   }
 
   .btn-inline {

--- a/src/app/components/utility/input/input.component.html
+++ b/src/app/components/utility/input/input.component.html
@@ -38,7 +38,7 @@
       grad-btn-transparent fs-14">
       <span> Upload File </span>
       <input name="fileUpload" id="file-upload-custom" [(ngModel)]="fileValue"
-        value="{{fileValue}}" accept="{{accept}}"
+        accept="{{accept}}"
         (change)="handleFileInput($event.target.files)" type="file"
         class="text-dark-black" [readonly]="isReadonly" />
     </div>


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Added a submission settings new column in the table of submission list

- Make use of update challenge data and visibility API

- On the new column added a gear icon for showing all submission settings over the menu

- Link to live demo: http://pr-172-evalai.surge.sh

**Screenshot:**

![Screenshot from 2019-07-16 00-21-55](https://user-images.githubusercontent.com/32524438/61240867-df347700-a75f-11e9-9c6c-29efa3b4b3ea.png)

