### PR TITLE
Collapsible challenge submission table UI

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
+import { MatCheckboxModule } from '@angular/material';
 
 // Import serivces
 import { AuthService } from './services/auth.service';
@@ -80,8 +81,8 @@ import {
 } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
 import { SideBarComponent } from './components/utility/side-bar/side-bar.component';
 
-import {MatTableModule} from '@angular/material/table';
-import {MatDividerModule} from '@angular/material/divider';
+import { MatTableModule } from '@angular/material/table';
+import { MatDividerModule } from '@angular/material/divider';
 import { DashboardContentComponent } from './components/dashboard/dashboard-content/dashboard-content.component';
 import {PasswordMismatchValidatorDirective} from './Directives/password.validator';
 import { ResetPasswordComponent } from './components/auth/reset-password/reset-password.component';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -80,6 +80,8 @@ import {
 } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
 import { SideBarComponent } from './components/utility/side-bar/side-bar.component';
 
+import {MatTableModule} from '@angular/material/table';
+import {MatDividerModule} from '@angular/material/divider';
 import { DashboardContentComponent } from './components/dashboard/dashboard-content/dashboard-content.component';
 import {PasswordMismatchValidatorDirective} from './Directives/password.validator';
 import { ResetPasswordComponent } from './components/auth/reset-password/reset-password.component';
@@ -160,7 +162,10 @@ import { ResetPasswordConfirmComponent } from './components/auth/reset-password-
     MatSelectModule,
     MatChipsModule,
     MatMenuModule,
-    MatIconModule
+    MatIconModule,
+    MatTableModule,
+    MatDividerModule,
+    MatCheckboxModule
   ],
   providers: [
     AuthService,

--- a/src/app/components/challenge/challenge.component.spec.ts
+++ b/src/app/components/challenge/challenge.component.spec.ts
@@ -24,7 +24,7 @@ import { InputComponent } from '../../components/utility/input/input.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import {FormsModule} from '@angular/forms';
+import {MatTableModule} from '@angular/material';
 
 describe('ChallengeComponent', () => {
   let component: ChallengeComponent;
@@ -68,7 +68,7 @@ describe('ChallengeComponent', () => {
           },
         },
       ],
-      imports: [ HttpClientModule, RouterTestingModule, FormsModule ],
+      imports: [ HttpClientModule, RouterTestingModule, MatTableModule ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();

--- a/src/app/components/challenge/challenge.component.spec.ts
+++ b/src/app/components/challenge/challenge.component.spec.ts
@@ -24,7 +24,8 @@ import { InputComponent } from '../../components/utility/input/input.component';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Observable, of } from 'rxjs';
-import {MatTableModule} from '@angular/material';
+import { MatTableModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
 
 describe('ChallengeComponent', () => {
   let component: ChallengeComponent;
@@ -68,7 +69,7 @@ describe('ChallengeComponent', () => {
           },
         },
       ],
-      imports: [ HttpClientModule, RouterTestingModule, MatTableModule ],
+      imports: [ HttpClientModule, RouterTestingModule, FormsModule, MatTableModule ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
@@ -63,13 +63,9 @@
           </div>
         </div>
       </div>
-      <div *ngIf="submissions.length > 0" class="display-flex pad-top">
-        <i class="fa fa-check-circle submitted marker"></i>
-        <span class="show-on-leaderboard">Shown on leaderboard</span>
-      </div>
     </div>
 
-    <div class="ev-card-body exist-team-card">
+    <div class="ev-card-body exist-team-card" *ngIf="!isPhaseSelected || (paginationDetails.showPagination == false && isPhaseSelected)">
       <div class="row row-lr-margin">
         <div class="col-md-12 col-lr-pad">
           <div *ngIf="!isPhaseSelected" class="result-wrn">No phase selected.</div>
@@ -78,78 +74,85 @@
         </div>
       </div>
     </div>
+    <div class="collapsible-table">
+      <table mat-table *ngIf="paginationDetails.showPagination == true && submissions.length > 0"
+             [dataSource]="submissions" multiTemplateDataRows
+             class="mat-elevation-z0 ev-md-container">
+        <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay; let i = index">
+          <th class="cell-outside text-dark-black fs-16" mat-header-cell *matHeaderCellDef> {{columnsHeadings[i]}} </th>
+          <td class="cell-outside fw-regular" mat-cell *matCellDef="let element" >
+            <a target="_blank" class="blue-text" [href]="element[column]" *ngIf="element[column] !== null && column !== 'status'">
+              <i class="fa fa-external-link"></i>
+              Link
+            </a>
+            <span [class.green-text]="column === 'status'" *ngIf="element[column] !== null && column === 'status'">{{element[column]}}</span>
+            <span *ngIf="element[column] === null">{{"None"}}</span>
+          </td>
+        </ng-container>
+        <ng-container matColumnDef="expandedDetail">
+          <td mat-cell *matCellDef="let element" [attr.colspan]="columnsToDisplay.length">
+            <div class="elements" [class.expanded-row]="element == expandedElement"
+                 [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+              <div class="elements-detail">
+                <div class="element">
+                  <span class="element-description-attribution">Team Name</span>
+                  <span class="fw-regular element-description"> {{element.participant_team_name}} </span>
+                </div>
+                <div class="element">
+                  <span class="element-description-attribution">Method Name</span>
+                  <span class="fw-regular element-description"> {{element.method_name}} </span>
+                </div>
+                <div class="element">
+                  <span class="element-description-attribution">Method Description</span>
+                  <span class="fw-regular element-description"> {{element.method_description}} </span>
+                </div>
+                <div class="element">
+                  <span class="element-description-attribution">Project Url</span>
+                  <span class="fw-regular element-description"> {{element.project_url}} </span>
+                </div>
+                <div class="element">
+                  <span class="element-description-attribution">Publication Url</span>
+                  <span class="fw-regular element-description"> {{element.publication_url}} </span>
+                </div>
+              </div>
 
-    <table mat-table *ngIf="paginationDetails.showPagination == true && submissions.length > 0"
-           [dataSource]="submissions" multiTemplateDataRows
-           class="mat-elevation-z0">
-      <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
-        <th mat-header-cell *matHeaderCellDef> {{column}} </th>
-        <td mat-cell *matCellDef="let element" >
-          <span *ngIf="element[column] !== null">{{element[column]}}</span>
-          <span *ngIf="element[column] === null">{{"None"}}</span>
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="expandedDetail">
-        <td mat-cell *matCellDef="let element" [attr.colspan]="columnsToDisplay.length">
-          <div class="elements" [class.expanded-row]="element == expandedElement"
-               [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
-            <div class="elements-detail">
-              <div class="element">
-                <span class="element-description-attribution">Team Name</span>
-                <span class="fw-regular element-description"> {{element.participant_team_name}} </span>
-              </div>
-              <div class="element">
-                <span class="element-description-attribution">Method Name</span>
-                <span class="fw-regular element-description"> {{element.method_name}} </span>
-              </div>
-              <div class="element">
-                <span class="element-description-attribution">Method Description</span>
-                <span class="fw-regular element-description"> {{element.method_description}} </span>
-              </div>
-              <div class="element">
-                <span class="element-description-attribution">Project Url</span>
-                <span class="fw-regular element-description"> {{element.project_url}} </span>
-              </div>
-              <div class="element">
-                <span class="element-description-attribution">Publication Url</span>
-                <span class="fw-regular element-description"> {{element.publication_url}} </span>
+              <div class="elements-action">
+                <div class="element">
+                  <span class="element-description-attribution">Status</span>
+                  <span class="fw-regular element-description" [ngClass]="element.status"> {{element.status}} </span>
+                </div>
+                <div class="element">
+                  <span class="element-description-attribution">Execution Time</span>
+                  <span class="fw-regular element-description"> {{element.execution_time}} </span>
+                </div>
+                <div class="element">
+                  <span class="element-description-attribution">Submitted At</span>
+                  <span class="fw-regular element-description"> {{element.submitted_at | date:'medium'}} </span>
+                </div>
+                <div class="element">
+                  <mat-checkbox [checked]="element.is_public" [disabled]="element.status !== 'finished' || !selectedPhase['leaderboard_public']" (change)="changeSubmissionVisibility(element.id, element.is_public)">
+                    Show On Leaderboard
+                  </mat-checkbox>
+                </div>
+                <div class="element">
+                  <a (click)="editSubmission(element)" >
+                    <i class="fa fa-pencil"></i>
+                  </a>
+                </div>
               </div>
             </div>
+          </td>
+        </ng-container>
 
-            <div class="elements-action">
-              <div class="element">
-                <span class="element-description-attribution">Status</span>
-                <span class="fw-regular element-description" [ngClass]="element.status"> {{element.status}} </span>
-              </div>
-              <div class="element">
-                <span class="element-description-attribution">Execution Time</span>
-                <span class="fw-regular element-description"> {{element.execution_time}} </span>
-              </div>
-              <div class="element">
-                <span class="element-description-attribution">Submitted At</span>
-                <span class="fw-regular element-description"> {{element.submitted_at | date:'medium'}} </span>
-              </div>
-              <div class="element">
-                <mat-checkbox [checked]="element.is_public" [disabled]="element.status !== 'finished' || !selectedPhase['leaderboard_public']" (change)="changeSubmissionVisibility(element.id, element.is_public)">
-                  Show On Leaderboard
-                </mat-checkbox>
-                <a (click)="editSubmission(element)" class="element-description">
-                  <i class="fa fa-pencil"></i>
-                </a>
-              </div>
-            </div>
-          </div>
-        </td>
-      </ng-container>
-
-      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
-      <tr mat-row *matRowDef="let element; columns: columnsToDisplay;"
-          class="element-row"
-          [class.expanded-row]="expandedElement === element"
-          (click)="expandedElement = expandedElement === element ? null : element">
-      </tr>
-      <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
-    </table>
+        <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+        <tr mat-row *matRowDef="let element; columns: columnsToDisplay;"
+            class="element-row"
+            [class.expanded-row]="expandedElement === element"
+            (click)="expandedElement = expandedElement === element ? null : element">
+        </tr>
+        <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
+      </table>
+    </div>
 
     <div class="pagination" *ngIf="paginationDetails.showPagination && submissions.length > 0">
       <div class="row row-lr-margin">

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.html
@@ -75,96 +75,81 @@
           <div *ngIf="!isPhaseSelected" class="result-wrn">No phase selected.</div>
           <div *ngIf="paginationDetails.showPagination == false && isPhaseSelected"
                class="result-wrn">No results found.</div>
-          <div *ngIf="paginationDetails.showPagination == true && submissions.length > 0"
-               class="table-scroll">
-            <table class="centered highlight all-submission-table">
-              <thead>
-                <tr class="content">
-                  <th data-field="team">Team Name</th>
-                  <th data-field="method-name">Method Name</th>
-                  <th data-field="method-description">Method Description</th>
-                  <th data-field="project-url">Project Url</th>
-                  <th data-field="publication-url">Publication Url </th>
-                  <th data-field="status">Status</th>
-                  <th data-field="status">Execution Time (sec.)</th>
-                  <th data-field="file">Submitted File</th>
-                  <th data-field="file">Result File</th>
-                  <th data-field="file">Stdout File</th>
-                  <th data-field="file">Stderr File</th>
-                  <th data-field="file">Submitted At</th>
-                  <th *ngIf="selectedPhase['leaderboard_public']"
-                    data-field="file">Show on Leaderboard</th>
-                  <th data-field="isBaseline" *ngIf="isChallengeHost">Baseline</th>
-                  <th>Edit</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr *ngFor="let key of submissions" class="result-val content">
-                  <td class="display-flex">
-                    <i *ngIf="key.public" class="fa fa-check-circle submitted marker"></i>
-                    {{key.participant_team_name}}
-                  </td>
-                  <td *ngIf="key.method_name != ''">{{key.method_name}}</td>
-                  <td *ngIf="key.method_name == ''"> None </td>
-
-                  <td *ngIf="key.method_description != ''">{{key.method_description}}</td>
-                  <td *ngIf="key.method_description == ''"> None </td>
-
-                  <td *ngIf="key.project_url != ''">{{key.project_url}}</td>
-                  <td *ngIf="key.project_url == ''"> None </td>
-
-                  <td *ngIf="key.publication_url != ''">{{key.publication_url}}</td>
-                  <td *ngIf="key.publication_url == ''"> None </td>
-
-                  <td class="mb-10 capitalize" [ngClass]="key.status">{{key.status}}</td>
-                  <td>{{key.execution_time > 0 ? key.execution_time : "None"}}</td>
-                  <td><a href="{{key.input_file}}" target="_blank"
-                      class="blue-text"><i class="fa fa-external-link"></i> Link</a></td>
-                  <td *ngIf="key.submission_result_file"><a
-                      href="{{key.submission_result_file}}" target="_blank"
-                      class="blue-text"><i class="fa fa-external-link"></i> Link</a></td>
-                  <td *ngIf="!key.submission_result_file">None</td>
-
-                  <td *ngIf="key.stdout_file"><a href="{{key.stdout_file}}"
-                      target="_blank" class="blue-text">
-                      <i class="fa fa-external-link"></i> Link</a></td>
-                  <td *ngIf="!key.stdout_file">None</td>
-
-                  <td *ngIf="key.stderr_file"><a href="{{key.stderr_file}}"
-                      target="_blank" class="blue-text">
-                      <i class="fa fa-external-link"></i> Link</a></td>
-                  <td *ngIf="!key.stderr_file">None</td>
-
-                  <td>{{key.submitted_at | date:'medium'}}</td>
-
-                  <td *ngIf="selectedPhase['leaderboard_public']"><div>
-                    <input [checked]="key.is_public" *ngIf="key.status == 'finished'"
-                      type="checkbox" id="isPublic{{ key.id }}"
-                      (change)="changeSubmissionVisibility(key.id,
-                      key.is_public)" class="cbx hidden" />
-                    <label for="isPublic{{ key.id }}" class="cbx-label"></label>
-                    <div *ngIf="key.status !== 'finished'" class="center"> N/A
-                    </div></div>
-                  </td>
-                  <td *ngIf="isChallengeHost">
-                    <input [checked]="key.is_baseline" *ngIf="key.status == 'finished'"
-                      type="checkbox" id="baselineSubmission{{ key.id }}"
-                      (change)="changeBaselineStatus(key.id, key.is_baseline)"
-                      class="cbx hidden" />
-                    <label for="baselineSubmission{{ key.id }}"
-                      class="cbx-label"></label>
-                    <span *ngIf="key.status !== 'finished'" class="center"> N/A
-                    </span>
-                  </td>
-                  <td><a class="pointer" (click)="editSubmission(key)">
-                    <i class="fa fa-pencil" aria-hidden="true"></i></a></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
         </div>
       </div>
     </div>
+
+    <table mat-table *ngIf="paginationDetails.showPagination == true && submissions.length > 0"
+           [dataSource]="submissions" multiTemplateDataRows
+           class="mat-elevation-z0">
+      <ng-container matColumnDef="{{column}}" *ngFor="let column of columnsToDisplay">
+        <th mat-header-cell *matHeaderCellDef> {{column}} </th>
+        <td mat-cell *matCellDef="let element" >
+          <span *ngIf="element[column] !== null">{{element[column]}}</span>
+          <span *ngIf="element[column] === null">{{"None"}}</span>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="expandedDetail">
+        <td mat-cell *matCellDef="let element" [attr.colspan]="columnsToDisplay.length">
+          <div class="elements" [class.expanded-row]="element == expandedElement"
+               [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+            <div class="elements-detail">
+              <div class="element">
+                <span class="element-description-attribution">Team Name</span>
+                <span class="fw-regular element-description"> {{element.participant_team_name}} </span>
+              </div>
+              <div class="element">
+                <span class="element-description-attribution">Method Name</span>
+                <span class="fw-regular element-description"> {{element.method_name}} </span>
+              </div>
+              <div class="element">
+                <span class="element-description-attribution">Method Description</span>
+                <span class="fw-regular element-description"> {{element.method_description}} </span>
+              </div>
+              <div class="element">
+                <span class="element-description-attribution">Project Url</span>
+                <span class="fw-regular element-description"> {{element.project_url}} </span>
+              </div>
+              <div class="element">
+                <span class="element-description-attribution">Publication Url</span>
+                <span class="fw-regular element-description"> {{element.publication_url}} </span>
+              </div>
+            </div>
+
+            <div class="elements-action">
+              <div class="element">
+                <span class="element-description-attribution">Status</span>
+                <span class="fw-regular element-description" [ngClass]="element.status"> {{element.status}} </span>
+              </div>
+              <div class="element">
+                <span class="element-description-attribution">Execution Time</span>
+                <span class="fw-regular element-description"> {{element.execution_time}} </span>
+              </div>
+              <div class="element">
+                <span class="element-description-attribution">Submitted At</span>
+                <span class="fw-regular element-description"> {{element.submitted_at | date:'medium'}} </span>
+              </div>
+              <div class="element">
+                <mat-checkbox [checked]="element.is_public" [disabled]="element.status !== 'finished' || !selectedPhase['leaderboard_public']" (change)="changeSubmissionVisibility(element.id, element.is_public)">
+                  Show On Leaderboard
+                </mat-checkbox>
+                <a (click)="editSubmission(element)" class="element-description">
+                  <i class="fa fa-pencil"></i>
+                </a>
+              </div>
+            </div>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="columnsToDisplay"></tr>
+      <tr mat-row *matRowDef="let element; columns: columnsToDisplay;"
+          class="element-row"
+          [class.expanded-row]="expandedElement === element"
+          (click)="expandedElement = expandedElement === element ? null : element">
+      </tr>
+      <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
+    </table>
 
     <div class="pagination" *ngIf="paginationDetails.showPagination && submissions.length > 0">
       <div class="row row-lr-margin">

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.scss
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.scss
@@ -59,11 +59,17 @@
   background: #4CAF50;
 }
 
-
+.collapsible-table{
+  overflow: auto;
+}
 
 tr.detail-row {
   height: 0;
   overflow: hidden;
+}
+
+.cell-outside {
+  padding: 8px;
 }
 
 tr.element-row:not(.expanded-row):hover {
@@ -75,10 +81,6 @@ tr.element-row:not(.expanded-row):hover {
 
 tr.element-row:not(.expanded-row):active {
   background: #efefef;
-}
-
-.element-row td {
-  font-weight: 400;
 }
 
 .expanded-row {
@@ -139,5 +141,12 @@ tr.element-row:not(.expanded-row):active {
     border-bottom-color: lightgrey;
     border-bottom-width: 1px;
     padding-bottom: 20px;
+  }
+  .element {
+    display: flex;
+    flex-direction: column;
+  }
+  .element-description {
+    margin-left: 0;
   }
 }

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.scss
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.scss
@@ -34,10 +34,6 @@
   margin-bottom: 20px;
 }
 
-table {
-  width: 160% !important;
-}
-
 .marker {
   margin-right: 10px;
   font-size: 20px;
@@ -61,4 +57,87 @@ table {
 
 .cbx:checked ~ .cbx-label {
   background: #4CAF50;
+}
+
+
+
+tr.detail-row {
+  height: 0;
+  overflow: hidden;
+}
+
+tr.element-row:not(.expanded-row):hover {
+  td {
+    color: #efefef;
+  }
+  background: #252833;
+}
+
+tr.element-row:not(.expanded-row):active {
+  background: #efefef;
+}
+
+.element-row td {
+  font-weight: 400;
+}
+
+.expanded-row {
+  margin-top: 24px;
+  margin-bottom: 14px;
+}
+
+.elements {
+  overflow: hidden;
+  display: flex;
+  flex-direction: row;
+}
+
+.elements-detail {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  border-right-style: solid;
+  border-right-width: 1px;
+  border-right-color: lightgrey;
+
+  padding-right: 80px;
+}
+
+.elements-action {
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  margin-left: 40px;
+}
+
+.element {
+  margin-bottom: 10px;
+}
+
+.element-description {
+  margin-left: 10px;
+}
+
+.element-description-attribution {
+  opacity: 0.5;
+}
+
+@include screen-small {
+  .elements {
+    flex-direction: column;
+  }
+  .elements-action {
+    margin-left: 0;
+    margin-top: 20px;
+  }
+  .elements-detail {
+    border-right-style: none;
+    padding-right: 0;
+
+    border-bottom-style: solid;
+    border-bottom-color: lightgrey;
+    border-bottom-width: 1px;
+    padding-bottom: 20px;
+  }
 }

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.spec.ts
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.spec.ts
@@ -11,6 +11,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ForceloginComponent } from '../../../components/utility/forcelogin/forcelogin.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import {MatTableModule} from '@angular/material';
 
 describe('ChallengesubmissionsComponent', () => {
   let component: ChallengesubmissionsComponent;
@@ -21,7 +22,7 @@ describe('ChallengesubmissionsComponent', () => {
       declarations: [ ChallengesubmissionsComponent ],
       providers: [ ChallengeService, GlobalService, AuthService, ApiService,
                    WindowService, EndpointsService ],
-      imports: [ HttpClientModule, RouterTestingModule ],
+      imports: [ HttpClientModule, RouterTestingModule, MatTableModule ],
       schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.spec.ts
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.spec.ts
@@ -11,7 +11,7 @@ import { HttpClientModule } from '@angular/common/http';
 import { ForceloginComponent } from '../../../components/utility/forcelogin/forcelogin.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import {MatTableModule} from '@angular/material';
+import { MatTableModule } from '@angular/material';
 
 describe('ChallengesubmissionsComponent', () => {
   let component: ChallengesubmissionsComponent;

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
@@ -9,13 +9,22 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { SelectphaseComponent } from '../../utility/selectphase/selectphase.component';
 import { InputComponent } from '../../utility/input/input.component';
 
+import {Observable} from 'rxjs';
+import {animate, state, style, transition, trigger} from '@angular/animations';
 /**
  * Component Class
  */
 @Component({
   selector: 'app-challengesubmissions',
   templateUrl: './challengesubmissions.component.html',
-  styleUrls: ['./challengesubmissions.component.scss']
+  styleUrls: ['./challengesubmissions.component.scss'],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed', style({height: '0px', minHeight: '0'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
 })
 export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
 
@@ -133,6 +142,10 @@ export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
    * To call the API inside modal for editing the submission
    */
   apiCall: any;
+
+  columnsToDisplay = ['status', 'stderr_file', 'stdout_file', 'submission_result_file'];
+
+  expandedElement: null;
 
   /**
    * Filter query as participant team name

--- a/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
+++ b/src/app/components/challenge/challengesubmissions/challengesubmissions.component.ts
@@ -9,8 +9,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { SelectphaseComponent } from '../../utility/selectphase/selectphase.component';
 import { InputComponent } from '../../utility/input/input.component';
 
-import {Observable} from 'rxjs';
-import {animate, state, style, transition, trigger} from '@angular/animations';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 /**
  * Component Class
  */
@@ -144,6 +143,7 @@ export class ChallengesubmissionsComponent implements OnInit, AfterViewInit {
   apiCall: any;
 
   columnsToDisplay = ['status', 'stderr_file', 'stdout_file', 'submission_result_file'];
+  columnsHeadings = ['Status', 'Stderr File', 'Stdout File', 'Submission Result File'];
 
   expandedElement: null;
 


### PR DESCRIPTION
Modified submission table into a collapsible one.

<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->


#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Modified challenge submission table into a collapsible one.
- Fields like status, stderr_file, stdout_file, submission_result_file are displayed outside collapsible
rest data remains inside collapsible.

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-187-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
![Screenshot from 2019-07-22 17-27-45](https://user-images.githubusercontent.com/17106489/61666648-0e8a3d00-aca6-11e9-9a56-c5c27707d929.png)

![Screenshot from 2019-07-22 16-32-03](https://user-images.githubusercontent.com/17106489/61666679-2366d080-aca6-11e9-940e-d02bd20be6a1.png)

