### PR TITLE
Fix organizations logos on small screen

### DIFF
--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -52,9 +52,8 @@
 }
 
 #fb-logo{
-  height: 175px;
+  height: 100px;
   width: 160px;
-  padding-bottom:30%;
 }
 
 #mapillary-logo{
@@ -69,12 +68,10 @@
 
 #draper-logo {
   height: 110px;
-  padding-bottom:5%;
 }
 
 #ebay-logo{
-  padding-top:5%;
-  height: 80px;
+  height: 90px;
   width:160px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Removed padding and decreased thhe height of `fb` logo

- Link to live demo: http://pr-194-evalai.surge.sh

Before | After fixing
------------ | -------------
![Screenshot from 2019-07-27 23-17-56](https://user-images.githubusercontent.com/32524438/61997808-e430e900-b0c4-11e9-80e6-778b5654ff23.png) | ![Screenshot from 2019-07-27 23-17-34](https://user-images.githubusercontent.com/32524438/61997811-f14dd800-b0c4-11e9-8242-b3044b7a5768.png)



