### PR TITLE
Fixed overlapping issue in auth pages

### DIFF
--- a/src/app/components/auth/login/login.component.html
+++ b/src/app/components/auth/login/login.component.html
@@ -13,6 +13,7 @@
     <div class="input-field align-left">
       <input type="text" id="name" class="dark-autofill" name="name" (focusin)="isnameFocused = true"
              (focusout)="isnameFocused = authService.getUser['name'] !== ''" [(ngModel)]="authService.getUser['name']"
+             (change)="isnameFocused = authService.getUser['name'] !== ''"
              #name="ngModel" minLength="3" required>
       <span class="form-icon form-icon-dark"><i class="fa fa-user"></i></span>
       <label for="name" [class.active]="isnameFocused">Username*</label>
@@ -27,6 +28,7 @@
              (paste)="authService.getUser['password'] = ''" class="dark-autofill" name="password"
              (focusin)="ispasswordFocused = true"
              (focusout)="ispasswordFocused = authService.getUser['password'] !== ''"
+             (change)="ispasswordFocused = authService.getUser['password'] !== ''"
              [(ngModel)]="authService.getUser['password']" #password='ngModel'
              autocomplete="new-password" minlength="8" required>
       <span class="form-icon form-icon-dark" (click)="authService.togglePasswordVisibility()">

--- a/src/app/components/auth/reset-password-confirm/reset-password-confirm.component.html
+++ b/src/app/components/auth/reset-password-confirm/reset-password-confirm.component.html
@@ -20,7 +20,8 @@
       <div class="input-field align-left">
         <input type="{{authService.canShowPassword ? 'text' : 'password'}}" id="new_password1" class="dark-autofill" name="password" #newpassword1='ngModel'
                (focusin)="isNewPassword1Focused = true"
-               (focusout)="isNewPassword1Focused = authService.regUser['new_password1'] !== ''"
+               (focusout)="isNewPassword1Focused = authService.getUser['new_password1'] !== ''"
+               (change)="isNewPassword1Focused = authService.getUser['new_password1'] !== ''"
                [(ngModel)]="authService.getUser['new_password1']" minlength="8" required>
         <span class="form-icon form-icon-dark" (click)="authService.togglePasswordVisibility()">
                     <i *ngIf="!authService.canShowPassword" class="fa fa-eye pointer"></i>
@@ -35,7 +36,8 @@
       <div class="input-field align-left">
         <input type="{{authService.canShowConfirmPassword ? 'text' : 'password'}}" id="new_password2" class="dark-autofill" name="confirm_password" #newpassword2 = 'ngModel'
                (focusin)="isNewPassword2Focused = true"
-               (focusout)="isNewPassword2Focused = authService.regUser['new_password_2'] !== ''"
+               (focusout)="isNewPassword2Focused = authService.getUser['new_password2'] !== ''"
+               (change)="isNewPassword1Focused = authService.getUser['new_password2'] !== ''"
                [(ngModel)]="authService.getUser['new_password2']" minlength="8" required>
         <span class="form-icon form-icon-dark" (click)="authService.toggleConfirmPasswordVisibility()">
                     <i *ngIf="!authService.canShowConfirmPassword" class="fa fa-eye pointer"></i>

--- a/src/app/components/auth/reset-password/reset-password.component.html
+++ b/src/app/components/auth/reset-password/reset-password.component.html
@@ -27,6 +27,7 @@
       <div class="input-field align-left">
         <input type="email" id="email" class="dark-autofill" name="email" #email="ngModel"
                (focusin)="isemailFocused = true" (focusout)="isemailFocused = authService.getUser['email'] !== ''"
+               (change)="isemailFocused = authService.getUser['email'] !== ''"
                [(ngModel)]="authService.getUser['email']" required>
         <span class="form-icon form-icon-dark"><i class="fa fa-envelope"></i></span>
         <label for="email" [class.active]="isemailFocused">Email*</label>

--- a/src/app/components/auth/signup/signup.component.html
+++ b/src/app/components/auth/signup/signup.component.html
@@ -14,6 +14,7 @@
     <div class="input-field align-left">
       <input type="text" id="name" class="dark-autofill" name="name" #name="ngModel"
              (focusin)="isnameFocused = true" (focusout)="isnameFocused = authService.regUser['name'] !== ''"
+             (change)="isnameFocused = authService.regUser['name'] !== ''"
              [(ngModel)]="authService.regUser['name']" minlength="3" required>
       <span class="form-icon form-icon-dark"><i class="fa fa-user"></i></span>
       <label for="name" [class.active]="isnameFocused">Username*</label>
@@ -26,6 +27,7 @@
     <div class="input-field align-left">
       <input type="email" id="email" class="dark-autofill" name="email" #email="ngModel"
              (focusin)="isemailFocused = true" (focusout)="isemailFocused = authService.regUser['email'] !== ''"
+             (change)="isemailFocused = authService.regUser['email'] !== ''"
              [(ngModel)]="authService.regUser['email']" required>
       <span class="form-icon form-icon-dark"><i class="fa fa-envelope"></i></span>
       <label for="email" [class.active]="isemailFocused">Email</label>
@@ -41,6 +43,7 @@
              (paste)="authService.regUser['password'] = ''" class="dark-autofill" name="password" #password="ngModel"
              (focusin)="ispasswordFocused = true"
              (focusout)="ispasswordFocused = authService.regUser['password'] !== ''"
+             (input)="ispasswordFocused = authService.regUser['password'] !== ''"
              [(ngModel)]="authService.regUser['password']" minlength="8"
              (change)="checkStrength(authService.regUser['password'])" required>
       <span class="form-icon form-icon-dark" (click)="authService.togglePasswordVisibility()">
@@ -64,6 +67,7 @@
              #confirm_password="ngModel"
              (focusin)="iscnfrmpasswordFocused = true"
              (focusout)="iscnfrmpasswordFocused = authService.regUser['confirm_password'] !== ''"
+             (change)="iscnfrmpasswordFocused = authService.regUser['confirm_password'] !== ''"
              [(ngModel)]="authService.regUser['confirm_password']" minlength="8" required>
       <span class="form-icon form-icon-dark" (click)="authService.toggleConfirmPasswordVisibility()">
                 <i *ngIf="!authService.canShowConfirmPassword" class="fa fa-eye pointer"></i>


### PR DESCRIPTION
Added (change) and (input) event to change activate input label for the input value.

<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Fixed the overlapping issue in auth pages when the saved credentials are used.
<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-203-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
![Screenshot from 2019-08-06 05-57-44](https://user-images.githubusercontent.com/17106489/62530950-7e083c80-b80f-11e9-89f3-6cb54c039c87.png)

![Screenshot from 2019-08-06 05-58-43](https://user-images.githubusercontent.com/17106489/62531006-8eb8b280-b80f-11e9-8c5e-0107e383c062.png)

