### PR TITLE
Unique link for filtered leaderboard entries

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -81,6 +81,7 @@ const routes: Routes = [
       {path: 'leaderboard', component: ChallengeleaderboardComponent},
       {path: 'leaderboard/:split', component: ChallengeleaderboardComponent},
       {path: 'leaderboard/:split/:entry', component: ChallengeleaderboardComponent},
+      {path: 'leaderboard/:split/filter/:day', component: ChallengeleaderboardComponent},
       {path: 'settings', component: ChallengesettingsComponent}
     ]
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,7 +10,8 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
-
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatDatepickerModule} from '@angular/material/datepicker';
 // Import serivces
 import { AuthService } from './services/auth.service';
 import { WindowService } from './services/window.service';
@@ -85,6 +86,7 @@ import {PasswordMismatchValidatorDirective} from './Directives/password.validato
 import { ResetPasswordComponent } from './components/auth/reset-password/reset-password.component';
 import { EmailValidatorDirective } from './Directives/email.validator';
 import { ResetPasswordConfirmComponent } from './components/auth/reset-password-confirm/reset-password-confirm.component';
+import {MatInputModule, MatNativeDateModule} from '@angular/material';
 @NgModule({
   declarations: [
     AppComponent,
@@ -160,7 +162,11 @@ import { ResetPasswordConfirmComponent } from './components/auth/reset-password-
     MatSelectModule,
     MatChipsModule,
     MatMenuModule,
-    MatIconModule
+    MatIconModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatDatepickerModule,
+    MatNativeDateModule
   ],
   providers: [
     AuthService,

--- a/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
+++ b/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.html
@@ -36,14 +36,22 @@
           <div class="col-sm-12 col-lr-pad">
             <div *ngIf="leaderboard.length <= 0 && selectedPhaseSplit == null"
               class="fw-regular result-wrn">No phase selected.</div>
-              <div *ngIf="leaderboard.length > 0 && selectedPhaseSplit"
+            <div *ngIf="leaderboard.length > 0 && selectedPhaseSplit"
                 class="result-wrn content">
-                <mat-chip-list>
-                  <mat-chip>B</mat-chip> - Baseline submission
-                </mat-chip-list>
-              </div>
+              <mat-chip-list>
+                <mat-chip>B</mat-chip> - Baseline submission
+              </mat-chip-list>
+            </div>
+            <mat-form-field class="example-full-width">
+              <input matInput [matDatepicker]="picker" placeholder="Choose a date"
+                     (dateInput)="goToUniqueLink($event)" >
+              <mat-datepicker-toggle matSuffix [for]="picker">
+                <mat-icon matDatepickerToggleIcon>keyboard_arrow_down</mat-icon>
+              </mat-datepicker-toggle>
+              <mat-datepicker #picker></mat-datepicker>
+            </mat-form-field>
 
-              <table *ngIf="leaderboard.length > 0 && selectedPhaseSplit" class="centered highlight">
+            <table *ngIf="leaderboard.length > 0 && selectedPhaseSplit" class="centered highlight">
                 <thead>
                   <tr class="content">
                     <td data-field="rank" class="align-center">
@@ -107,10 +115,11 @@
                     <td><div>{{ key.submission__submitted_at_formatted }}</div></td>
                   </tr>
                 </tbody>
-              </table>
-              <div *ngIf="leaderboard.length <= 0 && selectedPhaseSplit">
-                <p>No results to show!</p>
-              </div>
+            </table>
+
+            <div *ngIf="leaderboard.length <= 0 && selectedPhaseSplit">
+              <p>No results to show!</p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
+++ b/src/app/components/challenge/challengeleaderboard/challengeleaderboard.component.ts
@@ -240,7 +240,13 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit {
       } else if (SELF.router.url.split('/').length === 5) {
         SELF.router.navigate(['../' + phaseSplit['id']], {relativeTo: this.route});
       } else if (SELF.router.url.split('/').length === 6) {
-        SELF.router.navigate(['../../' + phaseSplit['id']], {relativeTo: this.route});
+        if (SELF.selectedPhaseSplit['id'] !== phaseSplit['id']) {
+          SELF.router.navigate(['../../' + phaseSplit['id']], {relativeTo: this.route});
+        }
+      } else if (SELF.router.url.split('/').length === 7) {
+        if (SELF.selectedPhaseSplit['id'] !== phaseSplit['id']) {
+          SELF.router.navigate(['../../../' + phaseSplit['id']], {relativeTo: this.route});
+        }
       }
       SELF.selectedPhaseSplit = phaseSplit;
       if (SELF.selectedPhaseSplit) {
@@ -270,11 +276,19 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit {
       if (params['entry']) {
         self.entryHighlighted = params['entry'];
         self.leaderboard.map((item) => {
-          item['is_highlighted'] = false;
-          if (self.entryHighlighted && item['submission__participant_team__team_name'] === self.entryHighlighted) {
-            item['is_highlighted'] = true;
+          item['is_highlighted'] = self.entryHighlighted && item['submission__participant_team__team_name'] === self.entryHighlighted;
+        });
+        console.log('Is highlited', self.leaderboard);
+      }
+      if (params['day']) {
+        const TEMP = [];
+        self.leaderboard.map((item) => {
+          const d2 = new Date(Date.parse(item['submission__submitted_at']));
+          if (d2.getTime() <= params['day']) {
+            TEMP.push(item);
           }
         });
+        self.leaderboard = TEMP;
       }
     });
   }
@@ -410,5 +424,17 @@ export class ChallengeleaderboardComponent implements OnInit, AfterViewInit {
       },
       () => {}
     );
+  }
+
+  goToUniqueLink(ele) {
+    console.log(ele.value.getTime());
+    console.log(this.selectedPhaseSplit['id']);
+    if (this.router.url.split('/').length === 6) {
+      this.router.navigate(['../', 'filter', ele.value.getTime()], {relativeTo: this.route});
+    } else if(this.router.url.split('/').length === 7) {
+      this.router.navigate(['../../', 'filter', ele.value.getTime()], {relativeTo: this.route});
+    } else {
+      this.router.navigate(['filter', ele.value.getTime()], {relativeTo: this.route});
+    }
   }
 }


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->


#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Added feature to filter the leaderboard entry on the basis of the day and make a unique link for that filtrered leaderboard.


<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-205-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
![uniqueleaderboard](https://user-images.githubusercontent.com/17106489/63229786-3a7bde00-c1d2-11e9-85dc-675df98a402a.gif)

