### PR TITLE
Removed vertical scrollbar from the modals

### DIFF
--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1428,7 +1428,6 @@ code {
     font-size: $fs-16;
     color: $gray-darker;
     padding: 30px;
-    overflow-y: scroll;
     .title {
       color: $med-black;
       padding: 10px;


### PR DESCRIPTION
Google Code-in task: Remove the scroll from the modals.

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Removed the "overflow-y" property from the base.scss

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-220-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
- On the left modal without "overflow-y: scroll", on the right with it. 
![comparison](https://user-images.githubusercontent.com/23532372/70342466-596fb000-1855-11ea-8e4e-5e45b7c7d2d1.png)