### PR TITLE
Removed the permanent minlength-8 statement from password field 

### DIFF
--- a/src/app/components/auth/signup/signup.component.html
+++ b/src/app/components/auth/signup/signup.component.html
@@ -51,7 +51,7 @@
                 <i *ngIf="authService.canShowPassword" class="fa fa-eye-slash pointer"></i>
             </span>
       <label for="password" [class.active]="ispasswordFocused">
-        <strong>Password-minlength:8 required</strong>
+        <strong>Password</strong>
         <span [style.color]="color">{{' ' + message}}</span>
       </label>
       <div class="wrn-msg text-highlight"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #2478,2479


#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
-the minlength of password field is removed and also the weak password status doesn't stay after clearing the password input field. 


<!-- Screenshots for the change: Add here the screenshot of the fix. -->
![70344657-327aa380-1880-11ea-95a3-5fbdc1636d55](https://user-images.githubusercontent.com/34577232/70370540-5d9bdc00-18ee-11ea-9b13-fb433194ad73.png)

-
