### PR TITLE
Fixed name alignment

### DIFF
--- a/src/app/components/our-team/our-team.component.html
+++ b/src/app/components/our-team/our-team.component.html
@@ -37,7 +37,8 @@
                     <div class="team-profile">
                         <img src="{{data.headshot || 'dist/images/logo.png'}}">
                         <div class="team-player">
-                            <div><strong class="text-dark-black">{{data.name}}</strong></div>
+                            <span class="text-name-tooltip">{{data.name}}</span>
+                            <strong class="text-dark-black">{{data.name}}</strong>
                             <div class="text-med-black">{{data.description}}</div>
                         </div>
                     </div>

--- a/src/app/components/our-team/our-team.component.html
+++ b/src/app/components/our-team/our-team.component.html
@@ -36,10 +36,10 @@
                     </div>
                     <div class="team-profile">
                         <img src="{{data.headshot || 'dist/images/logo.png'}}">
-                    </div>
-                    <div class="team-player">
-                        <div><strong class="text-dark-black">{{data.name}}</strong></div>
-                        <div class="text-med-black">{{data.description}}</div>
+                        <div class="team-player">
+                            <div><strong class="text-dark-black">{{data.name}}</strong></div>
+                            <div class="text-med-black">{{data.description}}</div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/components/our-team/our-team.component.scss
+++ b/src/app/components/our-team/our-team.component.scss
@@ -139,7 +139,7 @@
       }
       .team-player {
           text-align: right;
-          align-self: end;
+          align-self: flex-end;
           .text-dark-black {
               color: $dark-black;
               font-size: $fs-15;

--- a/src/app/components/our-team/our-team.component.scss
+++ b/src/app/components/our-team/our-team.component.scss
@@ -145,6 +145,7 @@
           color: $dark-black;
           font-size: $fs-15;
           font-weight: $fw-semibold;
+          padding-left: 30px;
       }
       .text-med-black {
           color: $dark-black;

--- a/src/app/components/our-team/our-team.component.scss
+++ b/src/app/components/our-team/our-team.component.scss
@@ -121,40 +121,41 @@
   }
 
   .team-profile {
-      display: block;
-      width: 60px;
-      height: 60px;
-      border-radius: 50%;
-      overflow: hidden;
-      position: absolute;
-      bottom: 25px;
-      left: 15px;
-      box-shadow: 0px 4px 8px #989898;
-      img {
-          width: 100%;
-      }
-  }
-
-  .team-player {
+      display: flex;
+      width: 100%;
+      height: 74px;
       position: absolute;
       bottom: 14px;
-      text-align: right;
-      padding-left: 50px;
-      right: 15px;
-      .text-dark-black {
-          color: $dark-black;
-          font-size: $fs-15;
-          font-weight: $fw-semibold;
-          padding-left: 30px;
+      padding: 0 15px;
+      justify-content: space-between;
+      img {
+          width: 60px;
+          height: 60px;
+          border-radius: 50%;
+          box-shadow: 0px 4px 8px #989898;
+          object-fit: cover;
+          object-position: top;
+          flex-shrink: 0;
       }
-      .text-med-black {
-          color: $dark-black;
-          font-size: $fs-13;
-      }
-      h4 {
-          font-size: $fs-16;
-      }
+      .team-player {
+          text-align: right;
+          align-self: end;
+          .text-dark-black {
+              color: $dark-black;
+              font-size: $fs-15;
+              font-weight: $fw-semibold;
+          }
+          .text-med-black {
+              color: $dark-black;
+              font-size: $fs-13;
+          }
+          h4 {
+              font-size: $fs-16;
+          }
+    }
   }
+
+
 
   .team-link-head {
       padding: 10px 5px 10px 5px;

--- a/src/app/components/our-team/our-team.component.scss
+++ b/src/app/components/our-team/our-team.component.scss
@@ -137,6 +137,29 @@
           object-position: top;
           flex-shrink: 0;
       }
+      &:hover .text-name-tooltip.enabled {
+          opacity: 1;
+          pointer-events: unset;
+      }
+      .text-name-tooltip.enabled {
+          @include box-shadow(0px, 0px, 5px, 0px, $overlay-light);
+          background: $gray-lighter;
+          position: absolute;
+          overflow: hidden;
+          left: 0;
+          right: 0;
+          bottom: 80%;
+          margin: 10px;
+          border-radius: 6px 6px 0 6px;
+          padding: 6px 12px;
+          word-break: break-word;
+          opacity: 0;
+          pointer-events: none;
+          transition: opacity 400ms;
+      }
+      .text-name-tooltip.disabled {
+          display: none;
+      }
       .team-player {
           text-align: right;
           align-self: flex-end;
@@ -144,6 +167,11 @@
               color: $dark-black;
               font-size: $fs-15;
               font-weight: $fw-semibold;
+              overflow: hidden;
+              word-break: break-word;
+              display: -webkit-box;
+              -webkit-line-clamp: 2;
+              -webkit-box-orient: vertical;
           }
           .text-med-black {
               color: $dark-black;

--- a/src/app/components/our-team/our-team.component.ts
+++ b/src/app/components/our-team/our-team.component.ts
@@ -73,6 +73,23 @@ export class OurTeamComponent implements OnInit {
     this.fetchOurTeamMembers();
   }
 
+  ngAfterViewChecked() {
+     const DIVS = document.querySelectorAll('.team-player');
+     
+     for (let i = 0; i < DIVS.length; i++) {
+        let tooltip = DIVS[i].getElementsByClassName('text-name-tooltip')[0];
+        let name = DIVS[i].getElementsByClassName('text-dark-black')[0];
+        
+        // Check if name is collapsed
+        if (name.scrollHeight > name.clientHeight) {
+           tooltip.className = "text-name-tooltip enabled";
+        }
+        else {
+           tooltip.className = "text-name-tooltip disabled";
+        }
+     }
+  }
+
   /**
    * Fetching team members
    */

--- a/src/app/components/our-team/our-team.component.ts
+++ b/src/app/components/our-team/our-team.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewChecked } from '@angular/core';
 import { ApiService } from '../../services/api.service';
 import { GlobalService } from '../../services/global.service';
 import { EndpointsService } from '../../services/endpoints.service';
@@ -13,7 +13,7 @@ import { Router, ActivatedRoute } from '@angular/router';
   templateUrl: './our-team.component.html',
   styleUrls: ['./our-team.component.scss']
 })
-export class OurTeamComponent implements OnInit {
+export class OurTeamComponent implements OnInit, AfterViewChecked {
 
    /**
    * Constructor.
@@ -75,17 +75,16 @@ export class OurTeamComponent implements OnInit {
 
   ngAfterViewChecked() {
      const DIVS = document.querySelectorAll('.team-player');
-     
+
      for (let i = 0; i < DIVS.length; i++) {
-        let tooltip = DIVS[i].getElementsByClassName('text-name-tooltip')[0];
-        let name = DIVS[i].getElementsByClassName('text-dark-black')[0];
-        
+        const TOOLTIP = DIVS[i].getElementsByClassName('text-name-tooltip')[0];
+        const NAME = DIVS[i].getElementsByClassName('text-dark-black')[0];
+
         // Check if name is collapsed
-        if (name.scrollHeight > name.clientHeight) {
-           tooltip.className = "text-name-tooltip enabled";
-        }
-        else {
-           tooltip.className = "text-name-tooltip disabled";
+        if (NAME.scrollHeight > NAME.clientHeight) {
+           TOOLTIP.className = 'text-name-tooltip enabled';
+        } else {
+           TOOLTIP.className = 'text-name-tooltip disabled';
         }
      }
   }

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1428,7 +1428,6 @@ code {
     font-size: $fs-16;
     color: $gray-darker;
     padding: 30px;
-    overflow-y: scroll;
     .title {
       color: $med-black;
       padding: 10px;


### PR DESCRIPTION
Google Code-in task: Fix the text adjustment on team page.
> Fix the text of team member name in our team page so that it could adjust if it goes too long.


#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Added the "padding-left" property to team member's name

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-227-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
- Screenshot with visible changes:
![preview](https://user-images.githubusercontent.com/23532372/70390696-9d85c080-19cd-11ea-9224-6882cbbdf7a6.png)

- People with short names are not affected by this change:
![other](https://user-images.githubusercontent.com/23532372/70390766-56e49600-19ce-11ea-8864-03f99e80c4ea.png)
