### PR TITLE
Lightened Placeholder Text

### DIFF
--- a/src/app/components/publiclists/teamlist/teamlist.component.scss
+++ b/src/app/components/publiclists/teamlist/teamlist.component.scss
@@ -156,6 +156,10 @@ span.link-team-user {
   color: #9d9d9d;
 }
 
+.input-field label {
+  color: #adb4d0;
+}
+
 @media only screen and (max-width: 992px) and (min-width: 601px) {
   .team-heading {
     margin-top: 30px;


### PR DESCRIPTION
#### Changes proposed in this pull request:
- Lightened Placeholder text on participant teams and host teams page

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
#### Screenshots below

- Before change: Color was #9e9e9e
![darker](https://user-images.githubusercontent.com/35180217/70393357-3b3ab900-19e9-11ea-826c-7f7fd2add485.png)


- After change: Color is now #adb4d0
![lighter](https://user-images.githubusercontent.com/35180217/70393361-44c42100-19e9-11ea-8456-5e2c09228c87.png)

