### PR TITLE
Load header and footer only once instead of on every page load

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <!-- The <router-outlet> tells the router where to display routed views. -->
-<app-header *ngIf="showNav"></app-header>
+<app-header-static *ngIf="showNav"></app-header-static>
 <router-outlet></router-outlet>
 <app-toast></app-toast>
 <app-loading *ngIf="isLoading"></app-loading>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,5 @@
 <!-- The <router-outlet> tells the router where to display routed views. -->
+<app-header *ngIf="showNav"></app-header>
 <router-outlet></router-outlet>
 <app-toast></app-toast>
 <app-loading *ngIf="isLoading"></app-loading>
@@ -6,3 +7,4 @@
 <app-modal *ngIf="modalParams['isModalVisible']" [params]="modalParams"></app-modal>
 <app-editphasemodal *ngIf="editPhaseModalParams['isEditPhaseModalVisible']" [params]="editPhaseModalParams"></app-editphasemodal>
 <app-terms-and-conditions-modal *ngIf="termsAndConditionsModalParams['isTermsAndConditionsModalVisible']" [params]="termsAndConditionsModalParams"></app-terms-and-conditions-modal>
+<app-footer *ngIf="showNav"></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
-  showNav: boolean = false;
+  showNav = false;
   /**
    * Constructor.
    * @param document  Window document injection
@@ -50,7 +50,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] === '/auth' || event['url'] === '/dashboard'){
+        if (event['url'] === '/auth' || event['url'] === '/dashboard') {
           this.showNav = false;
         } else {
           this.showNav = true;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,10 +3,9 @@ import {mergeMap, map, filter} from 'rxjs/operators';
 import { Component, OnInit, OnDestroy, HostListener, Inject } from '@angular/core';
 import { GlobalService } from './services/global.service';
 import { AuthService } from './services/auth.service';
-import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { Router, NavigationEnd, ActivatedRoute, NavigationStart } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
 import { Title } from '@angular/platform-browser';
-import { Router, NavigationStart } from '@angular/router';
 
 
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import {mergeMap, map, filter} from 'rxjs/operators';
 import { Component, OnInit, OnDestroy, HostListener, Inject } from '@angular/core';
 import { GlobalService } from './services/global.service';
 import { AuthService } from './services/auth.service';
-import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { Router, NavigationEnd, ActivatedRoute, NavigationStart } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
 import { Title } from '@angular/platform-browser';
 
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
-
+  showNav: boolean = false;
   /**
    * Constructor.
    * @param document  Window document injection
@@ -48,8 +48,16 @@ export class AppComponent implements OnInit, OnDestroy {
   private globalService: GlobalService,
   private authService: AuthService
   ) {
+    router.events.forEach((event) => {
+      if (event instanceof NavigationStart) {
+        if (event['url'] === '/auth' || event['url'] === '/dashboard'){
+          this.showNav = false;
+        } else {
+          this.showNav = true;
+        }
+      }
+    });
   }
-
   /**
    * Scroll event listener.
    */

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,7 +50,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] === '/auth/login' || event['url'] === '/dashboard' || event['url'] === '/auth/signup') {
+        if (event['url'] === '/auth/login' || event['url'] === '/web/dashboard' || event['url'] === '/auth/signup') {
           this.showNav = false;
         } else {
           this.showNav = true;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from './services/auth.service';
 import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
 import { Title } from '@angular/platform-browser';
+import { Router, NavigationStart } from '@angular/router';
 
 
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,8 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
-
+  header: boolean = false;
+  footer: boolean = false;
   /**
    * Constructor.
    * @param document  Window document injection
@@ -50,6 +51,23 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
   }
 
+ constructor(private router: Router) {
+    router.events.forEach((event) => {
+      if (event instanceof NavigationStart) {
+        if (event['url'] == '/components/auth' || event['url'] == '/components/dashboard') {
+          this.header = false;
+        } else {
+          this.header = true;
+        }
+        if (event['url'] == '/components/auth') {
+          this.footer = false;
+        } else {
+          this.footer = true;
+        }
+      }
+    }
+    
+  
   /**
    * Scroll event listener.
    */

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,15 +50,15 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] == '/auth' || event['url'] == '/dashboard' || event['url'] == '/analytics' || event['url'] == '/challenge-create') {
+        if (event['url'] === '/auth' || event['url'] === '/dashboard' || event['url'] === '/analytics' 
+            || event['url'] === '/challenge-create') {
           this.showNav = false;
         } else {
           this.showNav = true;
         }
       }
     });
-  }    
-  
+  }
   /**
    * Scroll event listener.
    */

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,7 @@ import {mergeMap, map, filter} from 'rxjs/operators';
 import { Component, OnInit, OnDestroy, HostListener, Inject } from '@angular/core';
 import { GlobalService } from './services/global.service';
 import { AuthService } from './services/auth.service';
-import { Router, NavigationEnd, ActivatedRoute, NavigationStart } from '@angular/router';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
 import { DOCUMENT } from '@angular/common';
 import { Title } from '@angular/platform-browser';
 
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
-  showNav: boolean = false;
+
   /**
    * Constructor.
    * @param document  Window document injection
@@ -48,16 +48,8 @@ export class AppComponent implements OnInit, OnDestroy {
   private globalService: GlobalService,
   private authService: AuthService
   ) {
-    router.events.forEach((event) => {
-      if (event instanceof NavigationStart) {
-        if (event['url'] === '/auth' || event['url'] === '/dashboard'){
-          this.showNav = false;
-        } else {
-          this.showNav = true;
-        }
-      }
-    });
   }
+
   /**
    * Scroll event listener.
    */

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,7 +50,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] === '/auth' || event['url'] === '/dashboard'{
+        if (event['url'] === '/auth' || event['url'] === '/dashboard'){
           this.showNav = false;
         } else {
           this.showNav = true;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,7 +30,6 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
-  
   /**
    * Constructor.
    * @param document  Window document injection
@@ -48,20 +47,16 @@ export class AppComponent implements OnInit, OnDestroy {
   private globalService: GlobalService,
   private authService: AuthService
   ) {
-  }
-
-  constructor(private router: Router) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] == '/auth' || event['url'] == '/dashboard') {
+        if (event['url'] == '/auth' || event['url'] == '/dashboard' || event['url'] == '/analytics' || event['url'] == '/challenge-create') {
           this.showNav = false;
         } else {
           this.showNav = true;
         }
       }
     });
-  }
-    
+  }    
   
   /**
    * Scroll event listener.

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,10 +50,10 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] === '/auth' || event['url'] === '/dashboard') {
+        if (event['url'] === '/auth/login' || event['url'] === '/dashboard' || event['url'] === '/auth/signup') {
           this.showNav = false;
         } else {
-          this.showNav = true;
+          this.showNav = false;
         }
       }
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,8 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
-  header: boolean = false;
-  footer: boolean = false;
+  
   /**
    * Constructor.
    * @param document  Window document injection

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,7 +53,7 @@ export class AppComponent implements OnInit, OnDestroy {
         if (event['url'] === '/auth/login' || event['url'] === '/dashboard' || event['url'] === '/auth/signup') {
           this.showNav = false;
         } else {
-          this.showNav = false;
+          this.showNav = true;
         }
       }
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -51,21 +51,17 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
   }
 
- constructor(private router: Router) {
+  constructor(private router: Router) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] == '/components/auth' || event['url'] == '/components/dashboard') {
-          this.header = false;
+        if (event['url'] == '/auth' || event['url'] == '/dashboard') {
+          this.showNav = false;
         } else {
-          this.header = true;
-        }
-        if (event['url'] == '/components/auth') {
-          this.footer = false;
-        } else {
-          this.footer = true;
+          this.showNav = true;
         }
       }
-    }
+    });
+  }
     
   
   /**

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -50,8 +50,7 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
-        if (event['url'] === '/auth' || event['url'] === '/dashboard' || event['url'] === '/analytics' 
-            || event['url'] === '/challenge-create') {
+        if (event['url'] === '/auth' || event['url'] === '/dashboard'{
           this.showNav = false;
         } else {
           this.showNav = true;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -30,6 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
   globalEditPhaseModalSubscription: any;
   globalTermsAndConditionsModalSubscription: any;
   globalServiceSubscriptionScrollTop: any;
+  showNav: boolean = false;
   /**
    * Constructor.
    * @param document  Window document injection

--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -1,3 +1,4 @@
+
 	<div class="about-container">
 		<div class="row">
 			<div class="col-lg-7 col-md-7 col-sm-12 col-xs-12 about-content-column">

--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -1,5 +1,3 @@
-<app-header-static></app-header-static>
-
 	<div class="about-container">
 		<div class="row">
 			<div class="col-lg-7 col-md-7 col-sm-12 col-xs-12 about-content-column">
@@ -28,4 +26,3 @@
 			</div>
 		</div>
     </div>
-<app-footer></app-footer>

--- a/src/app/components/analytics/analytics.component.html
+++ b/src/app/components/analytics/analytics.component.html
@@ -1,13 +1,9 @@
 <app-side-bar *ngIf="authService.isAuth"></app-side-bar>
-<app-header-static></app-header-static>
 <div class="web-container" [style.center]="!authService.isAuth">
   <div class="dashboard-flex">
     <div class="dashboard-content">
       <router-outlet></router-outlet>
     </div>
-    <app-footer [isDash]="true" *ngIf="authService.isAuth"></app-footer>
   </div>
 </div>
 <div class="clearfix"></div>
-
-<app-footer *ngIf="!authService.isAuth"></app-footer>

--- a/src/app/components/challenge-create/challenge-create.component.html
+++ b/src/app/components/challenge-create/challenge-create.component.html
@@ -1,5 +1,4 @@
 <app-side-bar *ngIf="authService.isAuth"></app-side-bar>
-<app-header-static></app-header-static>
 <div class="web-container" [style.center]="!authService.isAuth">
   <div class="challenge-create-flex">
     <div class="challenge-create-content">
@@ -47,8 +46,5 @@
       </section>
 
     </div>
-    <app-footer [isDash]="true" *ngIf="authService.isAuth"></app-footer>
   </div>
 </div>
-
-<app-footer *ngIf="!authService.isAuth"></app-footer>

--- a/src/app/components/challenge/challenge.component.html
+++ b/src/app/components/challenge/challenge.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="mid-container">
     <div class="challenge-container">
         <div class="challenge-card">
@@ -142,4 +141,3 @@
         <router-outlet></router-outlet>
     </div>
 </div>
-<app-footer></app-footer>

--- a/src/app/components/contact/contact.component.html
+++ b/src/app/components/contact/contact.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="contact-container">
 	<div class="row">
 		<div class="col-lg-8 col-md-8 col-sm-12 col-xs-12 ev-mt-50">
@@ -30,5 +29,4 @@
 		</div>
 	</div>
 </div>
-<app-footer></app-footer>
 

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -1,14 +1,10 @@
 <app-side-bar *ngIf="authService.isAuth"></app-side-bar>
-<app-header-static></app-header-static>
 <div class="web-container" [style.center]="!authService.isAuth">
   <div class="dashboard-flex">
     <div class="dashboard-content">
       <app-dashboard-content></app-dashboard-content>
     </div>
     <!--Dashboard-Footer-->
-    <app-footer [isDash]="true" *ngIf="authService.isAuth"></app-footer>
   </div>
 </div>
 <div class="clearfix"></div>
-
-<app-footer *ngIf="!authService.isAuth"></app-footer>

--- a/src/app/components/get-involved/get-involved.component.html
+++ b/src/app/components/get-involved/get-involved.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="container-top container align-center get-involved-container">
   <div>
     <h4 class="get-involved-title align-center fw-regular">Get Involved</h4>
@@ -93,4 +92,3 @@
     &nbsp;
   </div>
 </div>
-<app-footer></app-footer>

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="white-bg view-container flex-body">
   <div class="content">
     <!-- EvalAI into -->
@@ -242,5 +241,3 @@
   </div>
   <!--landing-footer></landing-footer-->
 </div>
-
-<app-footer></app-footer>

--- a/src/app/components/our-team/our-team.component.html
+++ b/src/app/components/our-team/our-team.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="container-top">
     <div class="our-team-container">
         <div class="our-team-title fw-regular">
@@ -87,5 +86,3 @@
         </div>
     </div>
 </div>
-
-<app-footer></app-footer>

--- a/src/app/components/privacy-policy/privacy-policy.component.html
+++ b/src/app/components/privacy-policy/privacy-policy.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="container-top container privacy-container rm-margin">
   <div class="privacy-nav-container col-lg-2 col-md-3 col-sm-5 col-xs-5">
     <ul>
@@ -252,4 +251,3 @@
     </p>
   </div>
 </div>
-<app-footer></app-footer>

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,4 +1,3 @@
-<app-header-static></app-header-static>
 <div class="main_content">
 	<app-side-bar style="background-color: rgb(250,250,250)"></app-side-bar>
 	<div class="container-fluid main_content">

--- a/src/app/components/publiclists/publiclists.component.html
+++ b/src/app/components/publiclists/publiclists.component.html
@@ -1,5 +1,4 @@
 <app-side-bar *ngIf="authService.isAuth"></app-side-bar>
-<app-header-static></app-header-static>
 <div class="web-container" [style.center]="!authService.isAuth">
   <div class="dashboard-flex">
     <div class="dashboard-content">
@@ -9,5 +8,3 @@
   </div>
 </div>
 <div class="clearfix"></div>
-
-<app-footer *ngIf="!authService.isAuth"></app-footer>

--- a/src/app/components/publiclists/publiclists.component.html
+++ b/src/app/components/publiclists/publiclists.component.html
@@ -4,7 +4,6 @@
     <div class="dashboard-content">
       <router-outlet></router-outlet>
     </div>
-    <app-footer [isDash]="true" *ngIf="authService.isAuth"></app-footer>
   </div>
 </div>
 <div class="clearfix"></div>


### PR DESCRIPTION
<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
Moves header and footer loading to the main app component to improve performance. Now, the header and footer only need to be loaded once rather than on every component load.

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-244-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
-
![image](https://user-images.githubusercontent.com/46196529/71206086-c3368380-2271-11ea-9c3b-96bcab5da08a.png)

![image](https://user-images.githubusercontent.com/46196529/71206104-d0ec0900-2271-11ea-9cfe-aa870ae03f6e.png)

![image](https://user-images.githubusercontent.com/46196529/71206092-c893ce00-2271-11ea-9286-13f71e80f7d2.png)