### PR TITLE
Add a soft check when editing phase details

### DIFF
--- a/src/app/components/challenge/challengephases/editphasemodal/editphasemodal.component.ts
+++ b/src/app/components/challenge/challengephases/editphasemodal/editphasemodal.component.ts
@@ -175,11 +175,23 @@ export class EditphasemodalComponent implements OnInit {
   /**
    * Modal Confirmed.
    */
-  confirmed(self) {
+  cconfirmed(self) {
     if (self.description === '') {
       self.denyCallback();
       self.isEditorFieldMessage = true;
       self.editorValidationMessage = 'This field cannot be empty!';
+      return;
+    }
+    if (self.maxSubmissionsPerDay > self.maxSubmissionsPerMonth) {
+      self.denyCallback();
+      self.isEditorFieldMessage = true;
+      self.editorValidationMessage = 'Max number of submissions per day cannot be greater than max number of submissions per month';
+      return;
+    }
+    if (self.maxSubmissionsPerMonth > self.maxSubmissions) {
+      self.denyCallback();
+      self.isEditorFieldMessage = true;
+      self.editorValidationMessage = 'Max number of submissions per month cannot be greater than max total submissions';
       return;
     }
     const PARAMS = self.globalService.formFields(self.formComponents);

--- a/src/app/components/challenge/challengephases/editphasemodal/editphasemodal.component.ts
+++ b/src/app/components/challenge/challengephases/editphasemodal/editphasemodal.component.ts
@@ -175,7 +175,7 @@ export class EditphasemodalComponent implements OnInit {
   /**
    * Modal Confirmed.
    */
-  cconfirmed(self) {
+  confirmed(self) {
     if (self.description === '') {
       self.denyCallback();
       self.isEditorFieldMessage = true;


### PR DESCRIPTION
As part of a Google Code-In task.

<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->


#### Changes proposed in this pull request:
* Include a soft-check to ensure that the host does not enter:
max submissions/day > max number of submissions/month > Max total submissions

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-265-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
