### PR TITLE
🎨 Fix UI problems in participants page

### DIFF
--- a/src/app/components/publiclists/teamlist/teamlist.component.html
+++ b/src/app/components/publiclists/teamlist/teamlist.component.html
@@ -14,7 +14,7 @@
           </ul>
           <section class="pagination" *ngIf="allTeams.length !== 0">
             <div class="row rm-gut">
-              <div class="col s12 m6 ">
+              <div class="col s12">
                 <a [class.disabled]="seeMore <= 1" class="btn-floating btn-pagination waves-effect waves-light " (click)="seeLessClicked()">
                   <i class="fa fa-chevron-left"></i>
                 </a>
@@ -33,7 +33,7 @@
       </div>
     </div>
     <div class="col s12 m6">
-      <div class=" ev-card-panel ev-z-depth-5">
+      <div class=" ev-card-panel ev-z-depth-5 margin-on-small">
         <div class="ev-md-container ev-panel-title"><strong>{{teamCreateTitle}}</strong></div>
         <div class="ev-md-container ev-card-body new-team-card">
           <form name="createTeamForm" #createTeamForm="ngForm" (ngSubmit)="createTeamSubmit(createTeamForm.valid)">

--- a/src/app/components/publiclists/teamlist/teamlist.component.scss
+++ b/src/app/components/publiclists/teamlist/teamlist.component.scss
@@ -161,3 +161,9 @@ span.link-team-user {
     margin-top: 30px;
   }
 }
+
+@media only screen and (max-width: $small-screen) {
+  .margin-on-small {
+    margin-top: 15px;
+  }
+}


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->


#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Fix pagination button wrapping to next line on medium-sized screens
- Fix cards overlapping on small screens

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-298-evalai.surge.sh <!-- Replace XXX with your PR no: -->

<!-- Screenshots for the change: Add here the screenshot of the fix. -->
Before | After
--------|--------
![localhost_4200_teams_participants](https://user-images.githubusercontent.com/44284655/75793738-cbdd2700-5d95-11ea-9a82-fba1cb42b7db.png) | ![localhost_4200_teams_participants (1)](https://user-images.githubusercontent.com/44284655/75793849-f6c77b00-5d95-11ea-9431-0310e94c546f.png)
![localhost_4200_teams_participants(Pixel 2)](https://user-images.githubusercontent.com/44284655/75793846-f5964e00-5d95-11ea-8c78-7ef5dd892e38.png) | ![localhost_4200_teams_participants(Pixel 2) (1)](https://user-images.githubusercontent.com/44284655/75793852-f7601180-5d95-11ea-98fa-602d0a600239.png)


