### PR TITLE
Refactoring App Module and App Routing Module

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,11 +1,6 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
-import { AuthComponent } from './components/auth/auth.component';
-import { LoginComponent } from './components/auth/login/login.component';
-import { SignupComponent } from './components/auth/signup/signup.component';
-import { VerifyEmailComponent } from './components/auth/verify-email/verify-email.component';
 import { PubliclistsComponent } from './components/publiclists/publiclists.component';
 import { ChallengelistComponent } from './components/publiclists/challengelist/challengelist.component';
 import { TeamlistComponent } from './components/publiclists/teamlist/teamlist.component';
@@ -13,18 +8,6 @@ import { ContactComponent } from './components/contact/contact.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
 import { GetInvolvedComponent } from './components/get-involved/get-involved.component';
 import { AboutComponent } from './components/about/about.component';
-import { ChallengeComponent } from './components/challenge/challenge.component';
-import { ChallengesettingsComponent } from './components/challenge/challengesettings/challengesettings.component';
-import { ChallengeoverviewComponent} from './components/challenge/challengeoverview/challengeoverview.component';
-import { ChallengeevaluationComponent } from './components/challenge/challengeevaluation/challengeevaluation.component';
-import { ChallengephasesComponent} from './components/challenge/challengephases/challengephases.component';
-import { ChallengeparticipateComponent } from './components/challenge/challengeparticipate/challengeparticipate.component';
-import { ChallengeleaderboardComponent } from './components/challenge/challengeleaderboard/challengeleaderboard.component';
-import { ChallengesubmitComponent } from './components/challenge/challengesubmit/challengesubmit.component';
-import { ChallengesubmissionsComponent } from './components/challenge/challengesubmissions/challengesubmissions.component';
-import {
-  ChallengeviewallsubmissionsComponent
-} from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
 import { ChallengeCreateComponent } from './components/challenge-create/challenge-create.component';
 import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { ProfileComponent } from './components/profile/profile.component';
@@ -32,8 +15,16 @@ import { OurTeamComponent } from './components/our-team/our-team.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
 import {AnalyticsComponent} from './components/analytics/analytics.component';
 import {HostAnalyticsComponent} from './components/analytics/host-analytics/host-analytics.component';
-import {ResetPasswordComponent} from './components/auth/reset-password/reset-password.component';
-import {ResetPasswordConfirmComponent} from './components/auth/reset-password-confirm/reset-password-confirm.component';
+import { ChallengeComponent } from './components/challenge/challenge.component';
+import { ChallengeoverviewComponent } from './components/challenge/challengeoverview/challengeoverview.component';
+import { ChallengeevaluationComponent } from './components/challenge/challengeevaluation/challengeevaluation.component';
+import { ChallengephasesComponent } from './components/challenge/challengephases/challengephases.component';
+import { ChallengeparticipateComponent } from './components/challenge/challengeparticipate/challengeparticipate.component';
+import { ChallengesubmitComponent } from './components/challenge/challengesubmit/challengesubmit.component';
+import { ChallengesubmissionsComponent } from './components/challenge/challengesubmissions/challengesubmissions.component';
+import { ChallengeviewallsubmissionsComponent } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
+import { ChallengeleaderboardComponent } from './components/challenge/challengeleaderboard/challengeleaderboard.component';
+import { ChallengesettingsComponent } from './components/challenge/challengesettings/challengesettings.component';
 
 const routes: Routes = [
   {
@@ -46,19 +37,6 @@ const routes: Routes = [
   {
     path: 'about',
     component: AboutComponent
-  },
-  {
-    path: 'auth',
-    component: AuthComponent,
-    children: [
-      {path: '', redirectTo: 'login', pathMatch: 'full'},
-      {path: 'login', component: LoginComponent},
-      {path: 'reset-password', component: ResetPasswordComponent},
-      {path: 'reset-password/confirm/:user_id/:reset_token', component: ResetPasswordConfirmComponent},
-      {path: 'signup', component: SignupComponent},
-      {path: 'verify-email/:token', component: VerifyEmailComponent},
-      {path: '**', redirectTo: 'login'}
-    ]
   },
   {
     path: 'challenge',
@@ -84,15 +62,15 @@ const routes: Routes = [
       {path: 'settings', component: ChallengesettingsComponent}
     ]
   },
-  {
-    path: 'challenges',
-    component: PubliclistsComponent,
-    children: [
-      {path: '', redirectTo: 'all', pathMatch: 'full'},
-      {path: 'all', component: ChallengelistComponent},
-      {path: 'me', component: ChallengelistComponent}
-    ]
-  },
+  // {
+  //   path: 'challenges',
+  //   component: PubliclistsComponent,
+  //   children: [
+  //     {path: '', redirectTo: 'all', pathMatch: 'full'},
+  //     {path: 'all', component: ChallengelistComponent},
+  //     {path: 'me', component: ChallengelistComponent}
+  //   ]
+  // },
   {
     path: 'challenge-create',
     component: ChallengeCreateComponent

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { HomeComponent } from './components/home/home.component';
 import { PubliclistsComponent } from './components/publiclists/publiclists.component';
-import { ChallengelistComponent } from './components/publiclists/challengelist/challengelist.component';
 import { TeamlistComponent } from './components/publiclists/teamlist/teamlist.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
@@ -15,16 +14,6 @@ import { OurTeamComponent } from './components/our-team/our-team.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
 import {AnalyticsComponent} from './components/analytics/analytics.component';
 import {HostAnalyticsComponent} from './components/analytics/host-analytics/host-analytics.component';
-import { ChallengeComponent } from './components/challenge/challenge.component';
-import { ChallengeoverviewComponent } from './components/challenge/challengeoverview/challengeoverview.component';
-import { ChallengeevaluationComponent } from './components/challenge/challengeevaluation/challengeevaluation.component';
-import { ChallengephasesComponent } from './components/challenge/challengephases/challengephases.component';
-import { ChallengeparticipateComponent } from './components/challenge/challengeparticipate/challengeparticipate.component';
-import { ChallengesubmitComponent } from './components/challenge/challengesubmit/challengesubmit.component';
-import { ChallengesubmissionsComponent } from './components/challenge/challengesubmissions/challengesubmissions.component';
-import { ChallengeviewallsubmissionsComponent } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
-import { ChallengeleaderboardComponent } from './components/challenge/challengeleaderboard/challengeleaderboard.component';
-import { ChallengesettingsComponent } from './components/challenge/challengesettings/challengesettings.component';
 
 const routes: Routes = [
   {
@@ -38,39 +27,6 @@ const routes: Routes = [
     path: 'about',
     component: AboutComponent
   },
-  {
-    path: 'challenge',
-    redirectTo: 'challenges'
-  },
-  {
-    path: 'challenge/:id',
-    component: ChallengeComponent,
-    children: [
-      {path: '', redirectTo: 'overview', pathMatch: 'full'},
-      {path: 'overview', component: ChallengeoverviewComponent},
-      {path: 'evaluation', component: ChallengeevaluationComponent},
-      {path: 'phases', component: ChallengephasesComponent},
-      {path: 'participate', component: ChallengeparticipateComponent},
-      {path: 'submit', component: ChallengesubmitComponent},
-      {path: 'my-submissions', component: ChallengesubmissionsComponent},
-      {path: 'my-submissions/:phase', component: ChallengesubmissionsComponent},
-      {path: 'mysubmissions/:phase/:submission', component: ChallengesubmissionsComponent},
-      {path: 'view-all-submissions', component: ChallengeviewallsubmissionsComponent},
-      {path: 'leaderboard', component: ChallengeleaderboardComponent},
-      {path: 'leaderboard/:split', component: ChallengeleaderboardComponent},
-      {path: 'leaderboard/:split/:entry', component: ChallengeleaderboardComponent},
-      {path: 'settings', component: ChallengesettingsComponent}
-    ]
-  },
-  // {
-  //   path: 'challenges',
-  //   component: PubliclistsComponent,
-  //   children: [
-  //     {path: '', redirectTo: 'all', pathMatch: 'full'},
-  //     {path: 'all', component: ChallengelistComponent},
-  //     {path: 'me', component: ChallengelistComponent}
-  //   ]
-  // },
   {
     path: 'challenge-create',
     component: ChallengeCreateComponent

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,18 +1,10 @@
 import { BrowserModule } from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { EmailValidator, FormsModule } from '@angular/forms';
-import { FroalaEditorModule, FroalaViewModule } from 'angular-froala-wysiwyg';
-import { TextareaAutosizeModule } from 'ngx-textarea-autosize';
-import { OwlDateTimeModule, OwlNativeDateTimeModule } from 'ng-pick-datetime';
-import { MatSelectModule } from '@angular/material/select';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatIconModule } from '@angular/material/icon';
-import { MatCheckboxModule } from '@angular/material';
 
-// Import serivces
+// Import services
 import { WindowService } from './services/window.service';
 import { ApiService } from './services/api.service';
 import { GlobalService } from './services/global.service';
@@ -23,144 +15,49 @@ import { EndpointsService } from './services/endpoints.service';
 // Import Components
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
-import { HeaderStaticComponent } from './components/nav/header-static/header-static.component';
 import { ContactComponent } from './components/contact/contact.component';
-import { FooterComponent } from './components/nav/footer/footer.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
-import { InputComponent } from './components/utility/input/input.component';
-import { ToastComponent } from './components/utility/toast/toast.component';
 import { GetInvolvedComponent } from './components/get-involved/get-involved.component';
 import { AboutComponent } from './components/about/about.component';
-import { CardlistComponent } from './components/utility/cardlist/cardlist.component';
-import { ForceloginComponent } from './components/utility/forcelogin/forcelogin.component';
-import { PhasecardComponent } from './components/challenge/challengephases/phasecard/phasecard.component';
-import { ConfirmComponent } from './components/utility/confirm/confirm.component';
-import { LoadingComponent } from './components/utility/loading/loading.component';
-import { SelectphaseComponent } from './components/utility/selectphase/selectphase.component';
 import { ChallengeCreateComponent } from './components/challenge-create/challenge-create.component';
-import { ModalComponent } from './components/utility/modal/modal.component';
-import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { ProfileComponent } from './components/profile/profile.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
 import { OurTeamComponent } from './components/our-team/our-team.component';
 import { NgxTwitterTimelineModule } from 'ngx-twitter-timeline';
 import { AnalyticsComponent } from './components/analytics/analytics.component';
 import { HostAnalyticsComponent } from './components/analytics/host-analytics/host-analytics.component';
-import { EditphasemodalComponent } from './components/challenge/challengephases/editphasemodal/editphasemodal.component';
-import {
-  TermsAndConditionsModalComponent
-} from './components/challenge/challengeparticipate/terms-and-conditions-modal/terms-and-conditions-modal.component';
-import { SideBarComponent } from './components/utility/side-bar/side-bar.component';
-
-import { MatTableModule } from '@angular/material/table';
-import { MatDividerModule } from '@angular/material/divider';
-import { DashboardContentComponent } from './components/dashboard/dashboard-content/dashboard-content.component';
-import {PasswordMismatchValidatorDirective} from './Directives/password.validator';
-import { EmailValidatorDirective } from './Directives/email.validator';
 import { AuthModule } from './components/auth/auth.module';
 import { PubliclistModule } from './components/publiclists/publiclist.module';
-// import { ChallengeModule } from './components/challenge/challenge.module';
 import { HomeModule } from './components/home/home.module';
-import { ChallengeevaluationComponent } from './components/challenge/challengeevaluation/challengeevaluation.component';
-import { ChallengeleaderboardComponent } from './components/challenge/challengeleaderboard/challengeleaderboard.component';
-import { ChallengeoverviewComponent } from './components/challenge/challengeoverview/challengeoverview.component';
-import { ChallengeparticipateComponent } from './components/challenge/challengeparticipate/challengeparticipate.component';
-import { ChallengephasesComponent } from './components/challenge/challengephases/challengephases.component';
-import { ChallengesettingsComponent } from './components/challenge/challengesettings/challengesettings.component';
-import { ChallengesubmissionsComponent } from './components/challenge/challengesubmissions/challengesubmissions.component';
-import { ChallengesubmitComponent } from './components/challenge/challengesubmit/challengesubmit.component';
-import { ChallengeviewallsubmissionsComponent } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
-import { ChallengeComponent } from './components/challenge/challenge.component';
-import { ChallengelistComponent } from './components/publiclists/challengelist/challengelist.component';
-import { ChallengecardComponent } from './components/publiclists/challengelist/challengecard/challengecard.component';
-import { TeamcardComponent } from './components/publiclists/teamlist/teamcard/teamcard.component';
-import { TeamlistComponent } from './components/publiclists/teamlist/teamlist.component';
-import { PubliclistsComponent } from './components/publiclists/publiclists.component';
-import { FeaturedChallengesComponent } from './components/home/featured-challenges/featured-challenges.component';
-import { HomemainComponent } from './components/home/homemain/homemain.component';
-import { PartnersComponent } from './components/home/partners/partners.component';
-import { RulesComponent } from './components/home/rules/rules.component';
-import { TestimonialsComponent } from './components/home/testimonials/testimonials.component';
-import { TwitterFeedComponent } from './components/home/twitter-feed/twitter-feed.component';
-import { HomeComponent } from './components/home/home.component';
 import { AuthService } from './services/auth.service';
+import { ChallengeModule } from './components/challenge/challenge.module';
+import { DashboardModule } from './components/dashboard/dashboard.module';
+
 @NgModule({
   declarations: [
     AppComponent,
-    HeaderStaticComponent,
-    FooterComponent,
     PrivacyPolicyComponent,
-    InputComponent,
     ContactComponent,
-    ToastComponent,
     GetInvolvedComponent,
     AboutComponent,
-    CardlistComponent,
-    ForceloginComponent,
-    PhasecardComponent,
-    ConfirmComponent,
-    LoadingComponent,
-    SelectphaseComponent,
     ChallengeCreateComponent,
-    ModalComponent,
-    DashboardComponent,
     ProfileComponent,
     NotFoundComponent,
     OurTeamComponent,
-    SideBarComponent,
     AnalyticsComponent,
-    DashboardContentComponent,
-    HostAnalyticsComponent,
-    PasswordMismatchValidatorDirective,
-    EmailValidatorDirective,
-    EditphasemodalComponent,
-    ChallengeevaluationComponent,
-    ChallengeleaderboardComponent,
-    ChallengeoverviewComponent,
-    ChallengeparticipateComponent,
-    ChallengephasesComponent,
-    ChallengesettingsComponent,
-    ChallengesubmissionsComponent,
-    ChallengesubmitComponent,
-    ChallengeviewallsubmissionsComponent,
-    ChallengeComponent,
-    TermsAndConditionsModalComponent,
-    // ChallengelistComponent,
-    // ChallengecardComponent,
-    // TeamcardComponent,
-    // TeamlistComponent,
-    // PubliclistsComponent,
-    FeaturedChallengesComponent,
-    HomemainComponent,
-    PartnersComponent,
-    RulesComponent,
-    TestimonialsComponent,
-    TwitterFeedComponent,
-    HomeComponent
+    HostAnalyticsComponent
   ],
   imports: [
     AuthModule,
-    // HomeModule,
+    HomeModule,
     PubliclistModule,
-    // ChallengeModule,
+    ChallengeModule,
+    DashboardModule,
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
     HttpClientModule,
-    FormsModule,
-    NgxTwitterTimelineModule,
-    FroalaEditorModule.forRoot(),
-    FroalaViewModule.forRoot(),
-    TextareaAutosizeModule,
-    OwlDateTimeModule,
-    OwlNativeDateTimeModule,
-    MatSelectModule,
-    MatChipsModule,
-    MatMenuModule,
-    MatIconModule,
-    MatTableModule,
-    MatDividerModule,
-    MatCheckboxModule
+    FormsModule
   ],
   providers: [
     WindowService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import { NgModule } from '@angular/core';
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { EmailValidator, FormsModule } from '@angular/forms';
 import { FroalaEditorModule, FroalaViewModule } from 'angular-froala-wysiwyg';
@@ -13,7 +13,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material';
 
 // Import serivces
-import { AuthService } from './services/auth.service';
 import { WindowService } from './services/window.service';
 import { ApiService } from './services/api.service';
 import { GlobalService } from './services/global.service';
@@ -23,132 +22,127 @@ import { EndpointsService } from './services/endpoints.service';
 
 // Import Components
 import { AppComponent } from './app.component';
-import { HomeComponent } from './components/home/home.component';
 import { AppRoutingModule } from './app-routing.module';
 import { HeaderStaticComponent } from './components/nav/header-static/header-static.component';
 import { ContactComponent } from './components/contact/contact.component';
 import { FooterComponent } from './components/nav/footer/footer.component';
 import { PrivacyPolicyComponent } from './components/privacy-policy/privacy-policy.component';
 import { InputComponent } from './components/utility/input/input.component';
-import { AuthComponent } from './components/auth/auth.component';
-import { LoginComponent } from './components/auth/login/login.component';
-import { SignupComponent } from './components/auth/signup/signup.component';
 import { ToastComponent } from './components/utility/toast/toast.component';
 import { GetInvolvedComponent } from './components/get-involved/get-involved.component';
 import { AboutComponent } from './components/about/about.component';
 import { CardlistComponent } from './components/utility/cardlist/cardlist.component';
-import { ChallengecardComponent } from './components/publiclists/challengelist/challengecard/challengecard.component';
-import { ChallengelistComponent } from './components/publiclists/challengelist/challengelist.component';
-import { TeamcardComponent } from './components/publiclists/teamlist/teamcard/teamcard.component';
-import { TeamlistComponent } from './components/publiclists/teamlist/teamlist.component';
-import { PubliclistsComponent } from './components/publiclists/publiclists.component';
 import { ForceloginComponent } from './components/utility/forcelogin/forcelogin.component';
-import { ChallengeComponent } from './components/challenge/challenge.component';
-import { ChallengeoverviewComponent } from './components/challenge/challengeoverview/challengeoverview.component';
-import { ChallengeevaluationComponent } from './components/challenge/challengeevaluation/challengeevaluation.component';
-import { ChallengephasesComponent } from './components/challenge/challengephases/challengephases.component';
-import { ChallengeparticipateComponent } from './components/challenge/challengeparticipate/challengeparticipate.component';
-import { ChallengeleaderboardComponent } from './components/challenge/challengeleaderboard/challengeleaderboard.component';
-import { ChallengesubmitComponent } from './components/challenge/challengesubmit/challengesubmit.component';
-import { ChallengesubmissionsComponent } from './components/challenge/challengesubmissions/challengesubmissions.component';
 import { PhasecardComponent } from './components/challenge/challengephases/phasecard/phasecard.component';
 import { ConfirmComponent } from './components/utility/confirm/confirm.component';
 import { LoadingComponent } from './components/utility/loading/loading.component';
 import { SelectphaseComponent } from './components/utility/selectphase/selectphase.component';
-import { HomemainComponent } from './components/home/homemain/homemain.component';
 import { ChallengeCreateComponent } from './components/challenge-create/challenge-create.component';
-import { VerifyEmailComponent } from './components/auth/verify-email/verify-email.component';
 import { ModalComponent } from './components/utility/modal/modal.component';
 import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { ProfileComponent } from './components/profile/profile.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
 import { OurTeamComponent } from './components/our-team/our-team.component';
-import { TwitterFeedComponent } from './components/home/twitter-feed/twitter-feed.component';
 import { NgxTwitterTimelineModule } from 'ngx-twitter-timeline';
-import { PartnersComponent } from './components/home/partners/partners.component';
-import { RulesComponent } from './components/home/rules/rules.component';
-import { TestimonialsComponent } from './components/home/testimonials/testimonials.component';
-import { FeaturedChallengesComponent } from './components/home/featured-challenges/featured-challenges.component';
-import { ChallengesettingsComponent } from './components/challenge/challengesettings/challengesettings.component';
 import { AnalyticsComponent } from './components/analytics/analytics.component';
 import { HostAnalyticsComponent } from './components/analytics/host-analytics/host-analytics.component';
 import { EditphasemodalComponent } from './components/challenge/challengephases/editphasemodal/editphasemodal.component';
 import {
   TermsAndConditionsModalComponent
 } from './components/challenge/challengeparticipate/terms-and-conditions-modal/terms-and-conditions-modal.component';
-import {
-  ChallengeviewallsubmissionsComponent
-} from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
 import { SideBarComponent } from './components/utility/side-bar/side-bar.component';
 
 import { MatTableModule } from '@angular/material/table';
 import { MatDividerModule } from '@angular/material/divider';
 import { DashboardContentComponent } from './components/dashboard/dashboard-content/dashboard-content.component';
 import {PasswordMismatchValidatorDirective} from './Directives/password.validator';
-import { ResetPasswordComponent } from './components/auth/reset-password/reset-password.component';
 import { EmailValidatorDirective } from './Directives/email.validator';
-import { ResetPasswordConfirmComponent } from './components/auth/reset-password-confirm/reset-password-confirm.component';
+import { AuthModule } from './components/auth/auth.module';
+import { PubliclistModule } from './components/publiclists/publiclist.module';
+// import { ChallengeModule } from './components/challenge/challenge.module';
+import { HomeModule } from './components/home/home.module';
+import { ChallengeevaluationComponent } from './components/challenge/challengeevaluation/challengeevaluation.component';
+import { ChallengeleaderboardComponent } from './components/challenge/challengeleaderboard/challengeleaderboard.component';
+import { ChallengeoverviewComponent } from './components/challenge/challengeoverview/challengeoverview.component';
+import { ChallengeparticipateComponent } from './components/challenge/challengeparticipate/challengeparticipate.component';
+import { ChallengephasesComponent } from './components/challenge/challengephases/challengephases.component';
+import { ChallengesettingsComponent } from './components/challenge/challengesettings/challengesettings.component';
+import { ChallengesubmissionsComponent } from './components/challenge/challengesubmissions/challengesubmissions.component';
+import { ChallengesubmitComponent } from './components/challenge/challengesubmit/challengesubmit.component';
+import { ChallengeviewallsubmissionsComponent } from './components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component';
+import { ChallengeComponent } from './components/challenge/challenge.component';
+import { ChallengelistComponent } from './components/publiclists/challengelist/challengelist.component';
+import { ChallengecardComponent } from './components/publiclists/challengelist/challengecard/challengecard.component';
+import { TeamcardComponent } from './components/publiclists/teamlist/teamcard/teamcard.component';
+import { TeamlistComponent } from './components/publiclists/teamlist/teamlist.component';
+import { PubliclistsComponent } from './components/publiclists/publiclists.component';
+import { FeaturedChallengesComponent } from './components/home/featured-challenges/featured-challenges.component';
+import { HomemainComponent } from './components/home/homemain/homemain.component';
+import { PartnersComponent } from './components/home/partners/partners.component';
+import { RulesComponent } from './components/home/rules/rules.component';
+import { TestimonialsComponent } from './components/home/testimonials/testimonials.component';
+import { TwitterFeedComponent } from './components/home/twitter-feed/twitter-feed.component';
+import { HomeComponent } from './components/home/home.component';
+import { AuthService } from './services/auth.service';
 @NgModule({
   declarations: [
     AppComponent,
-    HomeComponent,
     HeaderStaticComponent,
     FooterComponent,
     PrivacyPolicyComponent,
     InputComponent,
-    AuthComponent,
-    LoginComponent,
-    SignupComponent,
     ContactComponent,
     ToastComponent,
     GetInvolvedComponent,
     AboutComponent,
     CardlistComponent,
-    ChallengecardComponent,
-    ChallengelistComponent,
-    TeamcardComponent,
-    TeamlistComponent,
-    PubliclistsComponent,
     ForceloginComponent,
-    ChallengeComponent,
-    ChallengeoverviewComponent,
-    ChallengeevaluationComponent,
-    ChallengephasesComponent,
-    ChallengeparticipateComponent,
-    ChallengeleaderboardComponent,
-    ChallengesubmitComponent,
-    ChallengesubmissionsComponent,
     PhasecardComponent,
     ConfirmComponent,
     LoadingComponent,
     SelectphaseComponent,
-    HomemainComponent,
     ChallengeCreateComponent,
-    VerifyEmailComponent,
     ModalComponent,
     DashboardComponent,
     ProfileComponent,
     NotFoundComponent,
     OurTeamComponent,
-    TwitterFeedComponent,
-    PartnersComponent,
-    RulesComponent,
-    TestimonialsComponent,
-    ChallengesettingsComponent,
     SideBarComponent,
     AnalyticsComponent,
-    FeaturedChallengesComponent,
     DashboardContentComponent,
     HostAnalyticsComponent,
     PasswordMismatchValidatorDirective,
     EmailValidatorDirective,
-    ResetPasswordComponent,
     EditphasemodalComponent,
-    ResetPasswordConfirmComponent,
+    ChallengeevaluationComponent,
+    ChallengeleaderboardComponent,
+    ChallengeoverviewComponent,
+    ChallengeparticipateComponent,
+    ChallengephasesComponent,
+    ChallengesettingsComponent,
+    ChallengesubmissionsComponent,
+    ChallengesubmitComponent,
     ChallengeviewallsubmissionsComponent,
-    TermsAndConditionsModalComponent
+    ChallengeComponent,
+    TermsAndConditionsModalComponent,
+    // ChallengelistComponent,
+    // ChallengecardComponent,
+    // TeamcardComponent,
+    // TeamlistComponent,
+    // PubliclistsComponent,
+    FeaturedChallengesComponent,
+    HomemainComponent,
+    PartnersComponent,
+    RulesComponent,
+    TestimonialsComponent,
+    TwitterFeedComponent,
+    HomeComponent
   ],
   imports: [
+    AuthModule,
+    // HomeModule,
+    PubliclistModule,
+    // ChallengeModule,
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule,
@@ -169,13 +163,13 @@ import { ResetPasswordConfirmComponent } from './components/auth/reset-password-
     MatCheckboxModule
   ],
   providers: [
-    AuthService,
     WindowService,
+    AuthService,
     ApiService,
     GlobalService,
     ChallengeService,
     EndpointsService
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
 })
 export class AppModule { }

--- a/src/app/components/auth/auth-routing.module.ts
+++ b/src/app/components/auth/auth-routing.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AuthComponent } from './auth.component';
+import { LoginComponent } from './login/login.component';
+import { ResetPasswordComponent } from './reset-password/reset-password.component';
+import { ResetPasswordConfirmComponent } from './reset-password-confirm/reset-password-confirm.component';
+import { SignupComponent } from './signup/signup.component';
+import { VerifyEmailComponent } from './verify-email/verify-email.component';
+
+const routes: Routes = [
+  {
+    path: 'auth',
+    component: AuthComponent,
+    children: [
+      {path: '', redirectTo: 'login', pathMatch: 'full'},
+      {path: 'login', component: LoginComponent},
+      {path: 'reset-password', component: ResetPasswordComponent},
+      {path: 'reset-password/confirm/:user_id/:reset_token', component: ResetPasswordConfirmComponent},
+      {path: 'signup', component: SignupComponent},
+      {path: 'verify-email/:token', component: VerifyEmailComponent},
+      {path: '**', redirectTo: 'login'}
+    ]
+  },
+];
+@NgModule({
+  imports: [ RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class AuthRoutingModule {}

--- a/src/app/components/auth/auth.module.ts
+++ b/src/app/components/auth/auth.module.ts
@@ -1,0 +1,51 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+// import components
+import { LoginComponent } from './login/login.component';
+import { SignupComponent } from './signup/signup.component';
+import { ResetPasswordConfirmComponent } from './reset-password-confirm/reset-password-confirm.component';
+import { ResetPasswordComponent } from './reset-password/reset-password.component';
+import { VerifyEmailComponent } from './verify-email/verify-email.component';
+import { AuthComponent } from './auth.component';
+
+// import modules
+import { AuthRoutingModule } from './auth-routing.module';
+import { NavModule } from '../nav/nav.module';
+
+// import services
+import { AuthService } from '../../services/auth.service';
+
+
+@NgModule({
+  declarations: [
+    LoginComponent,
+    SignupComponent,
+    ResetPasswordConfirmComponent,
+    ResetPasswordComponent,
+    VerifyEmailComponent,
+    AuthComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    AuthRoutingModule,
+    FormsModule,
+    NavModule
+  ],
+  exports: [
+    LoginComponent,
+    SignupComponent,
+    ResetPasswordConfirmComponent,
+    ResetPasswordComponent,
+    VerifyEmailComponent,
+    AuthComponent,
+    NavModule
+  ],
+  providers: [
+    AuthService
+  ]
+})
+export class AuthModule { }

--- a/src/app/components/challenge/challenge-routing.module.ts
+++ b/src/app/components/challenge/challenge-routing.module.ts
@@ -1,0 +1,44 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ChallengeComponent } from './challenge.component';
+import { ChallengeoverviewComponent } from './challengeoverview/challengeoverview.component';
+import { ChallengeevaluationComponent } from './challengeevaluation/challengeevaluation.component';
+import { ChallengephasesComponent } from './challengephases/challengephases.component';
+import { ChallengeparticipateComponent } from './challengeparticipate/challengeparticipate.component';
+import { ChallengesubmitComponent } from './challengesubmit/challengesubmit.component';
+import { ChallengesubmissionsComponent } from './challengesubmissions/challengesubmissions.component';
+import { ChallengeviewallsubmissionsComponent } from './challengeviewallsubmissions/challengeviewallsubmissions.component';
+import { ChallengeleaderboardComponent } from './challengeleaderboard/challengeleaderboard.component';
+import { ChallengesettingsComponent } from './challengesettings/challengesettings.component';
+
+const routes: Routes = [
+  {
+    path: 'challenge',
+    redirectTo: 'challenges'
+  },
+  {
+    path: 'challenge/:id',
+    component: ChallengeComponent,
+    children: [
+      {path: '', redirectTo: 'overview', pathMatch: 'full'},
+      {path: 'overview', component: ChallengeoverviewComponent},
+      {path: 'evaluation', component: ChallengeevaluationComponent},
+      {path: 'phases', component: ChallengephasesComponent},
+      {path: 'participate', component: ChallengeparticipateComponent},
+      {path: 'submit', component: ChallengesubmitComponent},
+      {path: 'my-submissions', component: ChallengesubmissionsComponent},
+      {path: 'my-submissions/:phase', component: ChallengesubmissionsComponent},
+      {path: 'mysubmissions/:phase/:submission', component: ChallengesubmissionsComponent},
+      {path: 'view-all-submissions', component: ChallengeviewallsubmissionsComponent},
+      {path: 'leaderboard', component: ChallengeleaderboardComponent},
+      {path: 'leaderboard/:split', component: ChallengeleaderboardComponent},
+      {path: 'leaderboard/:split/:entry', component: ChallengeleaderboardComponent},
+      {path: 'settings', component: ChallengesettingsComponent}
+    ]
+  },
+];
+@NgModule({
+imports: [RouterModule.forChild(routes)],
+exports: [RouterModule]
+})
+export class ChallengeRoutingModule {}

--- a/src/app/components/challenge/challenge.module.ts
+++ b/src/app/components/challenge/challenge.module.ts
@@ -1,0 +1,99 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  MatChipsModule,
+  MatTableModule,
+  MatMenuModule,
+  MatSelectModule,
+  MatIconModule,
+  MatDividerModule,
+  MatCheckboxModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { FroalaEditorModule, FroalaViewModule } from 'angular-froala-wysiwyg';
+
+// import components
+import { ChallengeevaluationComponent } from './challengeevaluation/challengeevaluation.component';
+import { ChallengeleaderboardComponent } from './challengeleaderboard/challengeleaderboard.component';
+import { ChallengeoverviewComponent } from './challengeoverview/challengeoverview.component';
+import { ChallengeparticipateComponent } from './challengeparticipate/challengeparticipate.component';
+import { ChallengephasesComponent } from './challengephases/challengephases.component';
+import { ChallengesettingsComponent } from './challengesettings/challengesettings.component';
+import { ChallengesubmissionsComponent } from './challengesubmissions/challengesubmissions.component';
+import { ChallengesubmitComponent } from './challengesubmit/challengesubmit.component';
+import { ChallengeviewallsubmissionsComponent } from './challengeviewallsubmissions/challengeviewallsubmissions.component';
+import { TermsAndConditionsModalComponent } from './challengeparticipate/terms-and-conditions-modal/terms-and-conditions-modal.component';
+import { EditphasemodalComponent } from './challengephases/editphasemodal/editphasemodal.component';
+import { PhasecardComponent } from './challengephases/phasecard/phasecard.component';
+import { ChallengeComponent } from './challenge.component';
+
+// import Modules
+import { NavModule } from '../nav/nav.module';
+import { ChallengeRoutingModule } from './challenge-routing.module';
+import { PubliclistModule } from '../publiclists/publiclist.module';
+
+// import services
+import { ApiService } from '../../services/api.service';
+import { ChallengeService } from '../../services/challenge.service';
+import { AuthService } from '../../services/auth.service';
+import { GlobalService } from '../../services/global.service';
+
+@NgModule({
+  declarations: [
+    ChallengeevaluationComponent,
+    ChallengeleaderboardComponent,
+    ChallengeoverviewComponent,
+    ChallengeparticipateComponent,
+    ChallengephasesComponent,
+    EditphasemodalComponent,
+    PhasecardComponent,
+    ChallengesettingsComponent,
+    ChallengesubmissionsComponent,
+    ChallengesubmitComponent,
+    ChallengeviewallsubmissionsComponent,
+    TermsAndConditionsModalComponent,
+    ChallengeComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    FormsModule,
+    MatChipsModule,
+    MatTableModule,
+    MatMenuModule,
+    MatSelectModule,
+    MatIconModule,
+    MatDividerModule,
+    MatCheckboxModule,
+    FroalaEditorModule.forRoot(),
+    FroalaViewModule.forRoot(),
+    ChallengeRoutingModule,
+    PubliclistModule,
+    NavModule
+  ],
+  exports: [
+    ChallengeevaluationComponent,
+    ChallengeleaderboardComponent,
+    ChallengeoverviewComponent,
+    ChallengeparticipateComponent,
+    ChallengephasesComponent,
+    EditphasemodalComponent,
+    PhasecardComponent,
+    ChallengesettingsComponent,
+    ChallengesubmissionsComponent,
+    ChallengesubmitComponent,
+    ChallengeviewallsubmissionsComponent,
+    TermsAndConditionsModalComponent,
+    ChallengeComponent,
+    PubliclistModule,
+    NavModule
+  ],
+  providers: [
+    ChallengeService,
+    ApiService,
+    AuthService,
+    GlobalService
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+export class ChallengeModule { }

--- a/src/app/components/dashboard/dashboard.module.ts
+++ b/src/app/components/dashboard/dashboard.module.ts
@@ -1,0 +1,30 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+
+// import components
+import { DashboardComponent } from './dashboard.component';
+import { DashboardContentComponent } from './dashboard-content/dashboard-content.component';
+
+// import modules
+import { NavModule } from '../nav/nav.module';
+
+@NgModule({
+declarations: [
+  DashboardContentComponent,
+  DashboardComponent
+],
+imports: [
+  CommonModule,
+  RouterModule,
+  NavModule
+],
+exports: [
+  DashboardContentComponent,
+  DashboardComponent,
+  NavModule
+],
+schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+
+export class DashboardModule {}

--- a/src/app/components/home/home-routing.module.ts
+++ b/src/app/components/home/home-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { HomeComponent } from './home.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: HomeComponent,
+    data: {
+      'title': 'EvalAI - Welcome'
+    }
+  },
+];
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class HomeRoutingModule {}

--- a/src/app/components/home/home.module.ts
+++ b/src/app/components/home/home.module.ts
@@ -1,0 +1,39 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FeaturedChallengesComponent } from './featured-challenges/featured-challenges.component';
+import { HomemainComponent } from './homemain/homemain.component';
+import { PartnersComponent } from './partners/partners.component';
+import { RulesComponent } from './rules/rules.component';
+import { TestimonialsComponent } from './testimonials/testimonials.component';
+import { TwitterFeedComponent } from './twitter-feed/twitter-feed.component';
+import { HomeComponent } from './home.component';
+import { NgxTwitterTimelineModule } from 'ngx-twitter-timeline';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  declarations: [
+    FeaturedChallengesComponent,
+    HomemainComponent,
+    PartnersComponent,
+    RulesComponent,
+    TestimonialsComponent,
+    TwitterFeedComponent,
+    HomeComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    NgxTwitterTimelineModule
+  ],
+  exports: [
+    FeaturedChallengesComponent,
+    HomemainComponent,
+    PartnersComponent,
+    RulesComponent,
+    TestimonialsComponent,
+    TwitterFeedComponent,
+    HomeComponent
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+export class HomeModule { }

--- a/src/app/components/home/home.module.ts
+++ b/src/app/components/home/home.module.ts
@@ -1,5 +1,9 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgxTwitterTimelineModule } from 'ngx-twitter-timeline';
+import { RouterModule } from '@angular/router';
+
+// import components
 import { FeaturedChallengesComponent } from './featured-challenges/featured-challenges.component';
 import { HomemainComponent } from './homemain/homemain.component';
 import { PartnersComponent } from './partners/partners.component';
@@ -7,8 +11,9 @@ import { RulesComponent } from './rules/rules.component';
 import { TestimonialsComponent } from './testimonials/testimonials.component';
 import { TwitterFeedComponent } from './twitter-feed/twitter-feed.component';
 import { HomeComponent } from './home.component';
-import { NgxTwitterTimelineModule } from 'ngx-twitter-timeline';
-import { RouterModule } from '@angular/router';
+
+// import module
+import { NavModule } from '../nav/nav.module';
 
 @NgModule({
   declarations: [
@@ -23,7 +28,8 @@ import { RouterModule } from '@angular/router';
   imports: [
     CommonModule,
     RouterModule,
-    NgxTwitterTimelineModule
+    NgxTwitterTimelineModule,
+    NavModule
   ],
   exports: [
     FeaturedChallengesComponent,
@@ -32,7 +38,8 @@ import { RouterModule } from '@angular/router';
     RulesComponent,
     TestimonialsComponent,
     TwitterFeedComponent,
-    HomeComponent
+    HomeComponent,
+    NavModule
   ],
   schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
 })

--- a/src/app/components/nav/nav.module.ts
+++ b/src/app/components/nav/nav.module.ts
@@ -1,0 +1,32 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+
+// import component
+import { FooterComponent } from './footer/footer.component';
+import { HeaderStaticComponent } from './header-static/header-static.component';
+
+// import module
+import { UtilityModule } from '../utility/utility.module';
+
+@NgModule({
+declarations: [
+  FooterComponent,
+  HeaderStaticComponent
+],
+imports: [
+  CommonModule,
+  FormsModule,
+  RouterModule,
+  UtilityModule
+],
+exports: [
+  FooterComponent,
+  HeaderStaticComponent,
+  UtilityModule
+],
+schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+
+export class NavModule {}

--- a/src/app/components/publiclists/publiclist-routing.module.ts
+++ b/src/app/components/publiclists/publiclist-routing.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule, Routes } from '@angular/router';
+import { ChallengelistComponent } from './challengelist/challengelist.component';
+import { PubliclistsComponent } from './publiclists.component';
+
+const routes: Routes = [
+  {
+    path: 'challenge',
+    redirectTo: 'challenges'
+  },
+  {
+    path: 'challenges',
+    component: PubliclistsComponent,
+    children: [
+      {path: '', redirectTo: 'all', pathMatch: 'full'},
+      {path: 'all', component: ChallengelistComponent},
+      {path: 'me', component: ChallengelistComponent}
+    ]
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PubliclistRoutingModule {}

--- a/src/app/components/publiclists/publiclist.module.ts
+++ b/src/app/components/publiclists/publiclist.module.ts
@@ -1,0 +1,56 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+
+// import components
+import { ChallengelistComponent } from './challengelist/challengelist.component';
+import { ChallengecardComponent } from './challengelist/challengecard/challengecard.component';
+import { TeamcardComponent } from './teamlist/teamcard/teamcard.component';
+import { TeamlistComponent } from './teamlist/teamlist.component';
+import { PubliclistsComponent } from './publiclists.component';
+
+// import services
+import { ApiService } from '../../services/api.service';
+import { GlobalService } from '../../services/global.service';
+import { AuthService } from '../../services/auth.service';
+import { ChallengeService } from '../../services/challenge.service';
+
+// import routes
+import { PubliclistRoutingModule } from './publiclist-routing.module';
+
+// import Module
+import { NavModule } from '../nav/nav.module';
+
+@NgModule({
+  declarations: [
+    ChallengelistComponent,
+    ChallengecardComponent,
+    TeamcardComponent,
+    TeamlistComponent,
+    PubliclistsComponent
+  ],
+  imports: [
+    CommonModule,
+    RouterModule,
+    FormsModule,
+    PubliclistRoutingModule,
+    NavModule
+  ],
+  exports: [
+    ChallengelistComponent,
+    ChallengecardComponent,
+    TeamcardComponent,
+    TeamlistComponent,
+    PubliclistsComponent,
+    NavModule
+  ],
+  providers: [
+    ApiService,
+    GlobalService,
+    AuthService,
+    ChallengeService
+  ],
+  schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+export class PubliclistModule {}

--- a/src/app/components/utility/utility.module.ts
+++ b/src/app/components/utility/utility.module.ts
@@ -1,0 +1,70 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OwlDateTimeModule, OwlNativeDateTimeModule } from 'ng-pick-datetime';
+import { FroalaEditorModule, FroalaViewModule } from 'angular-froala-wysiwyg';
+import { RouterModule } from '@angular/router';
+import { MatChipsModule, MatTableModule, MatMenuModule, MatSelectModule, MatIconModule, MatDividerModule, MatCheckboxModule } from '@angular/material';
+import { FormsModule } from '@angular/forms';
+
+// import components
+import { CardlistComponent } from './cardlist/cardlist.component';
+import { ConfirmComponent } from './confirm/confirm.component';
+import { ForceloginComponent } from './forcelogin/forcelogin.component';
+import { InputComponent } from './input/input.component';
+import { LoadingComponent } from './loading/loading.component';
+import { ModalComponent } from './modal/modal.component';
+import { SelectphaseComponent } from './selectphase/selectphase.component';
+import { SideBarComponent } from './side-bar/side-bar.component';
+import { ToastComponent } from './toast/toast.component';
+
+// import Directives
+import { EmailValidatorDirective } from '../../Directives/email.validator';
+import { PasswordMismatchValidatorDirective } from '../../Directives/password.validator';
+
+@NgModule({
+declarations: [
+  CardlistComponent,
+  ConfirmComponent,
+  ForceloginComponent,
+  InputComponent,
+  LoadingComponent,
+  ModalComponent,
+  SelectphaseComponent,
+  SideBarComponent,
+  ToastComponent,
+  EmailValidatorDirective,
+  PasswordMismatchValidatorDirective
+],
+imports: [
+  CommonModule,
+  FormsModule,
+  MatChipsModule,
+  MatTableModule,
+  MatMenuModule,
+  MatSelectModule,
+  MatIconModule,
+  MatDividerModule,
+  MatCheckboxModule,
+  RouterModule,
+  OwlDateTimeModule,
+  OwlNativeDateTimeModule,
+  FroalaEditorModule.forRoot(),
+  FroalaViewModule.forRoot(),
+],
+exports: [
+
+  CardlistComponent,
+  ConfirmComponent,
+  ForceloginComponent,
+  InputComponent,
+  LoadingComponent,
+  ModalComponent,
+  SelectphaseComponent,
+  SideBarComponent,
+  ToastComponent,
+  EmailValidatorDirective,
+  PasswordMismatchValidatorDirective
+],
+schemas: [ CUSTOM_ELEMENTS_SCHEMA ],
+})
+export class UtilityModule {}


### PR DESCRIPTION
This PR includes the implementation of one of the part of ideas proposed in [here](https://github.com/Cloud-CV/GSoC-Ideas/issues/28).

Features added:
1. [app-module](https://github.com/Cloud-CV/EvalAI-ngx/blob/master/src/app/app.module.ts) splitted into smaller sub-module
2. [app-routing-module](https://github.com/Cloud-CV/EvalAI-ngx/blob/master/src/app/app-routing.module.ts) splitted into smaller sub-routes.

Refactoring Done for following Modules:

-  [x] Auth Module
-  [x] Challenge Module 
-  [x] Dashboard Module
-  [x] Home Module
-  [x] Nav Module
-  [x] Publiclist Module
-  [x] Utility Module

Refactoring TODO list:

-  [ ] Analysis Module
-  [ ] About Module
-  [ ] challenge-create Module
-  [ ] Contact Module
-  [ ] Get-involved Module
-  [ ] Not-found Module
-  [ ] Our-team Module
-  [ ] Privacy-Policy Module
-  [ ] Profile Module

GIF showing that all routes are working fine are refactoring:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/44888949/76705990-341ef780-670a-11ea-8446-abee8d56a655.gif)

Link to live demo: http://pr-299-evalai.surge.sh