### PR TITLE
Fix #190: Replace template driven form in auth pages with app input component

### DIFF
--- a/src/app/components/auth/login/login.component.html
+++ b/src/app/components/auth/login/login.component.html
@@ -1,63 +1,42 @@
 <div class="col s12 m6 offset-m3 left">
   <ul class="left">
     <li class="ev-horiz-list"><a [routerLink]="loginRoute" class="dark-link" routerLinkActive="active-auth"
-                                 (click)="authService.resetForm()">Log In</a></li>
+        (click)="authService.resetForm()">Log In</a></li>
     <li class="ev-horiz-list"><a [routerLink]="signupRoute" class="light-link" routerLinkActive="active-auth"
-                                 (click)="authService.resetForm()">Sign Up</a></li>
+        (click)="authService.resetForm()">Sign Up</a></li>
   </ul>
 </div>
-<div class="col s12 m6 offset-m3">
+<div class="col s12 m6 offset-m3" (keyup.enter)="formValidate()">
   <!-- login form -->
-  <form name="loginForm" #loginForm='ngForm' (ngSubmit)="userLogin(loginForm.valid)" id="log-in" novalidate>
-    <!-- username -->
-    <div class="input-field align-left">
-      <input type="text" id="name" class="dark-autofill" name="name" (focusin)="isnameFocused = true"
-             (focusout)="isnameFocused = authService.getUser['name'] !== ''" [(ngModel)]="authService.getUser['name']"
-             (change)="isnameFocused = authService.getUser['name'] !== ''"
-             #name="ngModel" minLength="3" required>
-      <span class="form-icon form-icon-dark"><i class="fa fa-user"></i></span>
-      <label for="name" [class.active]="isnameFocused">Username*</label>
-      <div class="wrn-msg text-highlight" *ngIf="name.invalid && (name.dirty || name.touched || loginForm.submitted)">
-        <p *ngIf="name.errors.minlength">Username is too short.</p>
-        <p *ngIf="name.errors.required">Username is required.</p>
-      </div>
+  <!-- username -->
+  <div class="input-field align-left">
+    <app-input [inputStyle]="'dark-autofill'" [label]="'name'" [type]="'text'" [placeholder]="'Username*'"
+      [isRequired]="true" [icon]="'fa fa-user'" #loginform>
+    </app-input>
+  </div>
+  <!-- password -->
+  <div class="input-field align-left">
+    <app-input [inputStyle]="'dark-autofill'" [label]="'password'" [type]="'password'"
+      [placeholder]="'Password (min 8 characters) *'" [isRequired]="true"
+      [icon]="authService.canShowPassword? 'fa fa-eye-slash pointer': 'fa fa-eye pointer'" #loginform>
+    </app-input>
+  </div>
+  <div class="row">
+    <br>
+    <div class="col s6 align-left rm-gut">
+      <button class="waves-effect waves-dark btn ev-btn-dark grad-btn grad-btn-dark w-300" type="submit"
+        (click)="formValidate()">Log In
+      </button>
     </div>
-    <!-- password -->
-    <div class="input-field align-left">
-      <input type="{{authService.canShowPassword ? 'text' : 'password'}}" id="password"
-             (paste)="authService.getUser['password'] = ''" class="dark-autofill" name="password"
-             (focusin)="ispasswordFocused = true"
-             (focusout)="ispasswordFocused = authService.getUser['password'] !== ''"
-             (change)="ispasswordFocused = authService.getUser['password'] !== ''"
-             [(ngModel)]="authService.getUser['password']" #password='ngModel'
-             autocomplete="new-password" minlength="8" required>
-      <span class="form-icon form-icon-dark" (click)="authService.togglePasswordVisibility()">
-                <i *ngIf="!authService.canShowPassword" class="fa fa-eye pointer"></i>
-                <i *ngIf="authService.canShowPassword" class="fa fa-eye-slash pointer"></i>
-            </span>
-      <label for="password" [class.active]="ispasswordFocused">Password (min 8 characters) *</label>
-      <div class="wrn-msg text-highlight"
-           *ngIf="password.invalid && (password.dirty || password.touched || loginForm.submitted)">
-        <p *ngIf="password.errors.minlength">Password is less than 8 characters.</p>
-        <p *ngIf="password.errors.required">Password is required.</p>
-      </div>
+    <div class="col s6 align-right right rm-gut">
+      <a routerLink="/auth/reset-password" class="light-link fg-pass">Forgot Password or Username?</a>
     </div>
-    <div class="row">
-      <br>
-      <div class="col s6 align-left rm-gut">
-        <button class="waves-effect waves-dark btn ev-btn-dark grad-btn grad-btn-dark w-300" type="submit">Log In
-        </button>
-      </div>
-      <div class="col s6 align-right right rm-gut">
-        <a routerLink="/auth/reset-password" class="light-link fg-pass">Forgot Password or Username?</a>
-      </div>
-    </div>
-    <div *ngIf="authService.isFormError" class="wrn-msg text-highlight align-left"> {{authService.FormError}}</div>
-    <div>
-      <p class="text-light-gray">
-        <span class="text-med-black">Start with a new account </span><a class="highlight-link"
-                                                                        [routerLink]="signupRoute"> Sign Up</a>
-      </p>
-    </div>
-  </form>
+  </div>
+  <div *ngIf="authService.isFormError" class="wrn-msg text-highlight align-left"> {{authService.FormError}}</div>
+  <div>
+    <p class="text-light-gray">
+      <span class="text-med-black">Start with a new account </span><a class="highlight-link" [routerLink]="signupRoute">
+        Sign Up</a>
+    </p>
+  </div>
 </div>

--- a/src/app/components/auth/login/login.component.ts
+++ b/src/app/components/auth/login/login.component.ts
@@ -99,17 +99,8 @@ export class LoginComponent implements OnInit, AfterViewInit {
 
   // Function to login
   userLogin(self) {
-    // if (!loginFormValid) {
-    //   this.globalService.stopLoader();
-    //   return;
-    // }
 
     self.globalService.startLoader('Taking you to EvalAI!');
-
-    // const LOGIN_BODY = {
-    //   'username': this.authService.getUser['name'],
-    //   'password': this.authService.getUser['password'],
-    // };
     const LOGIN_BODY = {
       username: self.globalService.formValueForLabel(self.components, 'name'),
       password: self.globalService.formValueForLabel(self.components, 'password')

--- a/src/app/components/auth/login/login.component.ts
+++ b/src/app/components/auth/login/login.component.ts
@@ -7,7 +7,7 @@ import { ApiService } from '../../../services/api.service';
 import { AuthService } from '../../../services/auth.service';
 import { GlobalService } from '../../../services/global.service';
 import { EndpointsService } from '../../../services/endpoints.service';
-import { Router, ActivatedRoute} from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 
 /**
  * Component Class
@@ -18,6 +18,13 @@ import { Router, ActivatedRoute} from '@angular/router';
   styleUrls: ['./login.component.scss']
 })
 export class LoginComponent implements OnInit, AfterViewInit {
+
+  /**
+   * Contains the fields for the login
+   */
+  loginForm = 'loginform';
+  @ViewChildren('loginform')
+  components: QueryList<InputComponent>;
 
   isnameFocused = false;
   ispasswordFocused = false;
@@ -49,13 +56,13 @@ export class LoginComponent implements OnInit, AfterViewInit {
    * @param endpointsService
    */
   constructor(@Inject(DOCUMENT) private document: Document,
-              private windowService: WindowService,
-              private globalService: GlobalService,
-              private apiService: ApiService,
-              public authService: AuthService,
-              private route: ActivatedRoute,
-              private router: Router,
-              private endpointsService: EndpointsService) {
+    private windowService: WindowService,
+    private globalService: GlobalService,
+    private apiService: ApiService,
+    public authService: AuthService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private endpointsService: EndpointsService) {
   }
 
   /**
@@ -85,49 +92,57 @@ export class LoginComponent implements OnInit, AfterViewInit {
     self.router.navigate([redirectTo]);
   }
 
+  // Validate Login Form
+  formValidate() {
+    this.globalService.formValidate(this.components, this.userLogin, this);
+  }
 
   // Function to login
-  userLogin(loginFormValid) {
-    if (!loginFormValid) {
-      this.globalService.stopLoader();
-      return;
-    }
+  userLogin(self) {
+    // if (!loginFormValid) {
+    //   this.globalService.stopLoader();
+    //   return;
+    // }
 
-    this.globalService.startLoader('Taking you to EvalAI!');
+    self.globalService.startLoader('Taking you to EvalAI!');
 
+    // const LOGIN_BODY = {
+    //   'username': this.authService.getUser['name'],
+    //   'password': this.authService.getUser['password'],
+    // };
     const LOGIN_BODY = {
-      'username': this.authService.getUser['name'],
-      'password': this.authService.getUser['password'],
+      username: self.globalService.formValueForLabel(self.components, 'name'),
+      password: self.globalService.formValueForLabel(self.components, 'password')
     };
 
-    this.apiService.postUrl(this.endpointsService.loginURL(), LOGIN_BODY).subscribe(
+    self.apiService.postUrl(self.endpointsService.loginURL(), LOGIN_BODY).subscribe(
       data => {
-        this.globalService.storeData(this.globalService.authStorageKey, data['token']);
-        this.authService.loggedIn(true);
-        this.globalService.stopLoader();
-        this.redirectCheck(this);
+        self.globalService.storeData(self.globalService.authStorageKey, data['token']);
+        self.authService.loggedIn(true);
+        self.globalService.stopLoader();
+        self.redirectCheck(self);
       },
 
       err => {
-        this.globalService.stopLoader();
+        self.globalService.stopLoader();
 
         if (err.status === 400) {
-          this.authService.isFormError = true;
+          self.authService.isFormError = true;
           try {
             const non_field_errors = typeof (err.error.non_field_errors) !== 'undefined';
             if (non_field_errors) {
-              this.authService.FormError = err.error.non_field_errors[0];
+              self.authService.FormError = err.error.non_field_errors[0];
             }
           } catch (error) {
             setTimeout(() => {
-              this.globalService.showToast('Error', 'Unable to Login.Please Try Again!', 5);
+              self.globalService.showToast('Error', 'Unable to Login.Please Try Again!', 5);
             }, 1000);
           }
         } else {
-          this.globalService.handleApiError(err);
+          self.globalService.handleApiError(err);
         }
       },
-      () => {}
+      () => { }
     );
   }
 

--- a/src/app/components/auth/reset-password/reset-password.component.html
+++ b/src/app/components/auth/reset-password/reset-password.component.html
@@ -3,12 +3,13 @@
     <ul class="align-left">
       <li>
         <br>
-        <span class="text-highlight">Password reset link has been sent to your registered email address. Please check your email inbox.</span>
+        <span class="text-highlight">Password reset link has been sent to your registered email address. Please check
+          your email inbox.</span>
       </li>
       <li>
         <br>
         <a [routerLink]="loginRoute" class="waves-effect waves-dark btn ev-btn-dark w-300" type="submit" value="Submit"
-           (click)="authService.resetForm()">Back to Log In</a>
+          (click)="authService.resetForm()">Back to Log In</a>
       </li>
     </ul>
   </div>
@@ -17,48 +18,32 @@
   <div class="col s12 m6 offset-m3 left">
     <ul class="left">
       <li class="ev-horiz-list"><a [routerLink]="resetPasswordRoute" class="light-link" routerLinkActive="active-auth"
-                                   (click)="authService.resetForm()">Enter email to reset password</a></li>
+          (click)="authService.resetForm()">Enter email to reset password</a></li>
     </ul>
   </div>
-  <div class="col s12 m6 offset-m3">
-    <form name="resetpassForm" #resetpassForm="ngForm" appValidateEmail (ngSubmit)="resetPassword(resetpassForm.valid)"
-          class="reset-password" novalidate>
-      <!-- email -->
-      <div class="input-field align-left">
-        <input type="email" id="email" class="dark-autofill" name="email" #email="ngModel"
-               (focusin)="isemailFocused = true" (focusout)="isemailFocused = authService.getUser['email'] !== ''"
-               (change)="isemailFocused = authService.getUser['email'] !== ''"
-               [(ngModel)]="authService.getUser['email']" required>
-        <span class="form-icon form-icon-dark"><i class="fa fa-envelope"></i></span>
-        <label for="email" [class.active]="isemailFocused">Email*</label>
-        <div class="wrn-msg text-highlight"
-             *ngIf="email.invalid && (email.dirty || email.touched || resetpassForm.submitted)">
-          <p *ngIf="email.errors.required">Email address is required.</p>
-        </div>
-        <div class="wrn-msg text-highlight"
-             *ngIf="resetpassForm.errors != null && email.valid && (email.dirty || email.touched || resetpassForm.submitted)">
-          <p *ngIf="resetpassForm.errors['InvalidEmail']">Please enter valid email address.</p>
-        </div>
+  <div class="col s12 m6 offset-m3" (keyup.enter)="formValidate()">
+    <!-- email -->
+    <div class="input-field align-left">
+      <app-input [inputStyle]="'dark-autofill'" [type]="'email'" [label]="'email'" [placeholder]="'Email'"
+        [isRequired]="true" [icon]="'fa fa-envelope'" #resetForm></app-input>
+    </div>
+    <div class="row">
+      <br>
+      <div class="col s6 align-left rm-gut">
+        <button class="waves-effect waves-dark btn ev-btn-dark w-300 grad-btn grad-btn-dark" type="submit"
+          value="Submit" (click)="formValidate()">Submit
+        </button>
       </div>
-      <div class="row">
-        <br>
-        <div class="col s6 align-left rm-gut">
-          <button class="waves-effect waves-dark btn ev-btn-dark w-300 grad-btn grad-btn-dark" type="submit"
-                  value="Submit">Submit
-          </button>
-        </div>
-        <div class="col s6 align-right right rm-gut">
-          <a [routerLink]="loginRoute" class="light-link fg-pass">Back to Log In</a>
-        </div>
+      <div class="col s6 align-right right rm-gut">
+        <a [routerLink]="loginRoute" class="light-link fg-pass">Back to Log In</a>
       </div>
-      <div *ngIf="authService.isFormError" class="wrn-msg text-highlight align-left"> {{authService.FormError}}</div>
-      <div>
-        <p class="text-light-gray">
-          <span class="text-med-black">Start with a new account </span><a class="highlight-link"
-                                                                          [routerLink]="signupRoute"
-                                                                          (click)="authService.resetForm()"> Sign Up</a>
-        </p>
-      </div>
-    </form>
+    </div>
+    <div *ngIf="authService.isFormError" class="wrn-msg text-highlight align-left"> {{authService.FormError}}</div>
+    <div>
+      <p class="text-light-gray">
+        <span class="text-med-black">Start with a new account </span><a class="highlight-link"
+          [routerLink]="signupRoute" (click)="authService.resetForm()"> Sign Up</a>
+      </p>
+    </div>
   </div>
 </div>

--- a/src/app/components/auth/reset-password/reset-password.component.spec.ts
+++ b/src/app/components/auth/reset-password/reset-password.component.spec.ts
@@ -1,13 +1,15 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {ResetPasswordComponent} from './reset-password.component';
-import {FormsModule} from '@angular/forms';
-import {AuthService} from '../../../services/auth.service';
-import {GlobalService} from '../../../services/global.service';
-import {EndpointsService} from '../../../services/endpoints.service';
-import {ApiService} from '../../../services/api.service';
-import {HttpClientModule} from '@angular/common/http';
-import {RouterTestingModule} from '@angular/router/testing';
+import { ResetPasswordComponent } from './reset-password.component';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../../../services/auth.service';
+import { GlobalService } from '../../../services/global.service';
+import { EndpointsService } from '../../../services/endpoints.service';
+import { ApiService } from '../../../services/api.service';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { InputComponent } from '../../utility/input/input.component';
+import { OwlDateTimeComponent, OwlDateTimeModule } from 'ng-pick-datetime';
 
 describe('ResetPasswordComponent', () => {
   let component: ResetPasswordComponent;
@@ -15,9 +17,9 @@ describe('ResetPasswordComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ResetPasswordComponent],
+      declarations: [ResetPasswordComponent, InputComponent],
       providers: [AuthService, GlobalService, EndpointsService, ApiService],
-      imports: [HttpClientModule, RouterTestingModule, FormsModule]
+      imports: [HttpClientModule, RouterTestingModule, FormsModule, OwlDateTimeModule]
     })
       .compileComponents();
   }));

--- a/src/app/components/auth/reset-password/reset-password.component.ts
+++ b/src/app/components/auth/reset-password/reset-password.component.ts
@@ -1,8 +1,9 @@
-import {Component, OnInit} from '@angular/core';
-import {AuthService} from '../../../services/auth.service';
-import {ApiService} from '../../../services/api.service';
-import {EndpointsService} from '../../../services/endpoints.service';
-import {GlobalService} from '../../../services/global.service';
+import { Component, OnInit, ViewChildren, QueryList } from '@angular/core';
+import { AuthService } from '../../../services/auth.service';
+import { ApiService } from '../../../services/api.service';
+import { EndpointsService } from '../../../services/endpoints.service';
+import { GlobalService } from '../../../services/global.service';
+import { InputComponent } from '../../utility/input/input.component';
 
 @Component({
   selector: 'app-reset-password',
@@ -29,6 +30,12 @@ export class ResetPasswordComponent implements OnInit {
   resetPasswordRoute = '/auth/reset-password';
 
   /**
+   * Form for the reset of the password
+   */
+  @ViewChildren('resetForm')
+  resetForm: QueryList<InputComponent>;
+
+  /**
    *
    * @param authService
    * @param globalService
@@ -36,44 +43,43 @@ export class ResetPasswordComponent implements OnInit {
    * @param endpointService
    */
   constructor(public authService: AuthService, private globalService: GlobalService, private apiService: ApiService,
-              private endpointService: EndpointsService) {
+    private endpointService: EndpointsService) {
   }
 
   ngOnInit() {
     this.authService.resetForm();
   }
 
+  formValidate() {
+    this.globalService.formValidate(this.resetForm, this.resetPassword, this);
+  }
   // function to reset password
-  resetPassword(resetPassFormValid) {
-    if (resetPassFormValid) {
-      this.globalService.startLoader('Sending Mail');
+  resetPassword(self) {
+    self.globalService.startLoader('Sending Mail');
 
-      const RESET_BODY = JSON.stringify({
-        email: this.authService.getUser['email']
-      });
+    const RESET_BODY = JSON.stringify({
+      email: self.globalService.formValueForLabel(self.resetForm, 'email')
+    });
 
-      const API_PATH = this.endpointService.resetPasswordURL();
+    const API_PATH = self.endpointService.resetPasswordURL();
 
-      this.apiService.postUrl(API_PATH, RESET_BODY).subscribe(
-        response => {
-          this.authService.isMail = false;
-          this.authService.getUser['error'] = false;
-          this.authService.isFormError = false;
-          this.authService.deliveredMsg = response.detail;
-          this.authService.getUser['email'] = '';
-          this.globalService.stopLoader();
-        },
+    self.apiService.postUrl(API_PATH, RESET_BODY).subscribe(
+      response => {
+        self.authService.isMail = false;
+        self.authService.getUser['error'] = false;
+        self.authService.isFormError = false;
+        self.authService.deliveredMsg = response.detail;
+        self.authService.getUser['email'] = '';
+        self.globalService.stopLoader();
+      },
 
-        err => {
-          this.authService.isFormError = true;
-          this.authService.FormError = 'Something went wrong. Please try again';
-          this.globalService.stopLoader();
-        },
+      err => {
+        self.authService.isFormError = true;
+        self.authService.FormError = 'Something went wrong. Please try again';
+        self.globalService.stopLoader();
+      },
 
-        () => {}
-      );
-    } else {
-      this.globalService.stopLoader();
-    }
+      () => { }
+    );
   }
 }

--- a/src/app/components/auth/signup/signup.component.html
+++ b/src/app/components/auth/signup/signup.component.html
@@ -1,101 +1,50 @@
 <div class="col s12 m6 offset-m3 left">
   <ul class="left">
     <li class="ev-horiz-list"><a [routerLink]="loginRoute" class="light-link" routerLinkActive="active-auth"
-                                 (click)="authService.resetForm()">Log In</a></li>
+        (click)="authService.resetForm()">Log In</a></li>
     <li class="ev-horiz-list"><a [routerLink]="signupRoute" class="dark-link" routerLinkActive="active-auth"
-                                 (click)="authService.resetForm()">Sign Up</a></li>
+        (click)="authService.resetForm()">Sign Up</a></li>
   </ul>
 </div>
-<div class="col s12 m6 offset-m3">
+<div class="col s12 m6 offset-m3" (keyup.enter)="formValidate()">
   <!-- login form -->
-  <form name="signupForm" #signupForm="ngForm" appComparePassword (ngSubmit)="userSignUp(signupForm.valid)" id="sign-up"
-        novalidate>
-    <!-- username -->
-    <div class="input-field align-left">
-      <input type="text" id="name" class="dark-autofill" name="name" #name="ngModel"
-             (focusin)="isnameFocused = true" (focusout)="isnameFocused = authService.regUser['name'] !== ''"
-             (change)="isnameFocused = authService.regUser['name'] !== ''"
-             [(ngModel)]="authService.regUser['name']" minlength="3" required>
-      <span class="form-icon form-icon-dark"><i class="fa fa-user"></i></span>
-      <label for="name" [class.active]="isnameFocused">Username*</label>
-      <div class="wrn-msg text-highlight" *ngIf="name.invalid && (name.dirty || name.touched || signupForm.submitted)">
-        <p *ngIf="name.errors.minlength">Username is too short.</p>
-        <p *ngIf="name.errors.required">Username is required.</p>
-      </div>
-    </div>
-    <!-- email -->
-    <div class="input-field align-left">
-      <input type="email" id="email" class="dark-autofill" name="email" #email="ngModel"
-             (focusin)="isemailFocused = true" (focusout)="isemailFocused = authService.regUser['email'] !== ''"
-             (change)="isemailFocused = authService.regUser['email'] !== ''"
-             [(ngModel)]="authService.regUser['email']" required>
-      <span class="form-icon form-icon-dark"><i class="fa fa-envelope"></i></span>
-      <label for="email" [class.active]="isemailFocused">Email</label>
-      <div class="wrn-msg text-highlight"
-           *ngIf="email.invalid && (email.dirty || email.touched || signupForm.submitted)">
-        <p *ngIf="email.errors.minlength">Please enter a valid email address.</p>
-        <p *ngIf="email.errors.required">Email address is required.</p>
-      </div>
-    </div>
-    <!-- password -->
-    <div class="input-field align-left">
-      <input type="{{authService.canShowPassword ? 'text' : 'password'}}" id="password"
-             (paste)="authService.regUser['password'] = ''" class="dark-autofill" name="password" #password="ngModel"
-             (focusin)="ispasswordFocused = true"
-             (focusout)="ispasswordFocused = authService.regUser['password'] !== ''"
-             (input)="ispasswordFocused = authService.regUser['password'] !== ''"
-             [(ngModel)]="authService.regUser['password']" minlength="8"
-             (change)="checkStrength(authService.regUser['password'])" required>
-      <span class="form-icon form-icon-dark" (click)="authService.togglePasswordVisibility()">
-                <i *ngIf="!authService.canShowPassword" class="fa fa-eye pointer"></i>
-                <i *ngIf="authService.canShowPassword" class="fa fa-eye-slash pointer"></i>
-            </span>
-      <label for="password" [class.active]="ispasswordFocused">
-        <strong>Password (Minimum 8 Characters) *</strong>
-        <span [style.color]="color">{{' ' + message}}</span>
-      </label>
-      <div class="wrn-msg text-highlight"
-           *ngIf="password.invalid && (password.dirty || password.touched || signupForm.submitted)">
-        <p *ngIf="password.errors.minlength">Password is less than 8 characters.</p>
-        <p *ngIf="password.errors.required">Password is required.</p>
-      </div>
-    </div>
-    <!-- confirm password -->
-    <div class="input-field align-left">
-      <input type="{{authService.canShowConfirmPassword ? 'text' : 'password'}}" id="confirm_password"
-             (paste)="authService.regUser['confirm_password'] = ''" class="dark-autofill" name="confirm_password"
-             #confirm_password="ngModel"
-             (focusin)="iscnfrmpasswordFocused = true"
-             (focusout)="iscnfrmpasswordFocused = authService.regUser['confirm_password'] !== ''"
-             (change)="iscnfrmpasswordFocused = authService.regUser['confirm_password'] !== ''"
-             [(ngModel)]="authService.regUser['confirm_password']" minlength="8" required>
-      <span class="form-icon form-icon-dark" (click)="authService.toggleConfirmPasswordVisibility()">
-                <i *ngIf="!authService.canShowConfirmPassword" class="fa fa-eye pointer"></i>
-                <i *ngIf="authService.canShowConfirmPassword" class="fa fa-eye-slash pointer"></i>
-            </span>
-      <label for="confirm_password" [class.active]="iscnfrmpasswordFocused">Confirm Password *</label>
-      <div class="wrn-msg text-highlight"
-           *ngIf="(confirm_password.invalid ) && (confirm_password.dirty || confirm_password.touched || signupForm.submitted)">
-        <p *ngIf="confirm_password.errors.minlength">Password is less than 8 characters.</p>
-        <p *ngIf="confirm_password.errors.required">Password confirmation is required.</p>
-      </div>
-      <div class="wrn-msg text-highlight"
-           *ngIf="signupForm.errors !== null && confirm_password.valid && (confirm_password.dirty || confirm_password.touched || signupForm.submitted)">
-        <p *ngIf="signupForm.errors['passwordMismatch']">Passwords do not match</p>
-      </div>
-    </div>
-    <!-- submit button -->
-    <div class="align-left reg-control">
-      <button class="waves-effect waves-dark btn ev-btn-dark grad-btn grad-btn-dark w-300" type="submit" value="Submit">
-        Sign Up
-      </button>
-    </div>
-    <div *ngIf="authService.isFormError" class="text-highlight align-left"> {{authService.FormError}}</div>
-    <div>
-      <p class="text-light-gray">
-        <span class="text-med-black">Already have an account? </span> <a class="highlight-link" [routerLink]="loginRoute">Log
+  <!-- username -->
+  <div class="input-field align-left">
+    <app-input [inputStyle]="'dark-autofill'" [type]="'text'" [label]="'name'" [placeholder]="'Username*'"
+      [isRequired]="true" [icon]="'fa fa-user'" #signupForm></app-input>
+  </div>
+  <!-- email -->
+  <div class="input-field align-left">
+    <app-input [inputStyle]="'dark-autofill'" [type]="'email'" [label]="'email'" [placeholder]="'Email'"
+      [isRequired]="true" [icon]="'fa fa-envelope'" #signupForm>
+    </app-input>
+  </div>
+  <!-- password -->
+  <div class="input-field align-left">
+    <app-input [inputStyle]="'dark-autofill'" [type]="'password'" [label]="'password'"
+      [placeholder]="'Password (Minimum 8 Characters) *'" [isRequired]="true" [icon]="'fa fa-eye pointer'" #signupForm
+      #password>
+    </app-input>
+  </div>
+  <!-- confirm password -->
+  <div class="input-field align-left">
+    <app-input [inputStyle]="'dark-autofill'" [type]="'password'" [label]="'confirm_password'"
+      [placeholder]="'Confirm Password *'" [isRequired]="true" [validate]="globalService.validateTwoPassword"
+      [fieldToCompare]="password.value" #signupForm></app-input>
+  </div>
+  <!-- submit button -->
+  <div class="align-left reg-control">
+    <button class="waves-effect waves-dark btn ev-btn-dark grad-btn grad-btn-dark w-300" type="submit" value="Submit"
+      (click)="formValidate()">
+      Sign Up
+    </button>
+  </div>
+  <div *ngIf="authService.isFormError" class="text-highlight align-left"> {{authService.FormError}}</div>
+  <div>
+    <p class="text-light-gray">
+      <span class="text-med-black">Already have an account? </span> <a class="highlight-link"
+        [routerLink]="loginRoute">Log
         In</a>
-      </p>
-    </div>
-  </form>
+    </p>
+  </div>
 </div>

--- a/src/app/components/auth/signup/signup.component.html
+++ b/src/app/components/auth/signup/signup.component.html
@@ -29,7 +29,7 @@
   <!-- confirm password -->
   <div class="input-field align-left">
     <app-input [inputStyle]="'dark-autofill'" [type]="'password'" [label]="'confirm_password'"
-      [placeholder]="'Confirm Password *'" [isRequired]="true" [validate]="globalService.validateTwoPassword"
+      [placeholder]="'Confirm Password *'" [isRequired]="true" [validate]="validateTwoPassword"
       [fieldToCompare]="password.value" #signupForm></app-input>
   </div>
   <!-- submit button -->

--- a/src/app/components/auth/signup/signup.component.ts
+++ b/src/app/components/auth/signup/signup.component.ts
@@ -75,6 +75,20 @@ export class SignupComponent implements OnInit, AfterViewInit {
    */
     ngAfterViewInit() { }
 
+    /**
+   * Custom validator to check equality of the password fields
+   * @param password1 The confirm password field
+   * @param password2 The password field
+   * @return returns an object that contain a message and a boolean
+   */
+    validateTwoPassword(password1: string, password2: string) {
+        const is_valid = password1 === password2;
+        return {
+            is_valid,
+            message: !is_valid ? 'Passwords do not match' : ''
+        };
+    }
+
     formValidate() {
         this.globalService.formValidate(this.signupForm, this.userSignUp, this);
     }

--- a/src/app/components/auth/signup/signup.component.ts
+++ b/src/app/components/auth/signup/signup.component.ts
@@ -1,45 +1,49 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit, Inject, ViewChildren, QueryList } from '@angular/core';
 import { AfterViewInit } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import {WindowService} from '../../../services/window.service';
-import {ApiService} from '../../../services/api.service';
-import {EndpointsService} from '../../../services/endpoints.service';
-import {GlobalService} from '../../../services/global.service';
-import {Router, ActivatedRoute} from '@angular/router';
-import {AuthService} from '../../../services/auth.service';
+import { WindowService } from '../../../services/window.service';
+import { ApiService } from '../../../services/api.service';
+import { EndpointsService } from '../../../services/endpoints.service';
+import { GlobalService } from '../../../services/global.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { AuthService } from '../../../services/auth.service';
+import { InputComponent } from '../../utility/input/input.component';
 
 /**
  * Component Class
  */
 @Component({
-  selector: 'app-signup',
-  templateUrl: './signup.component.html',
-  styleUrls: ['./signup.component.scss']
+    selector: 'app-signup',
+    templateUrl: './signup.component.html',
+    styleUrls: ['./signup.component.scss']
 })
-
-
 export class SignupComponent implements OnInit, AfterViewInit {
+    color = '';
+    message = '';
 
+    isnameFocused = false;
+    ispasswordFocused = false;
+    iscnfrmpasswordFocused = false;
+    isemailFocused = false;
 
-  color = '';
-  message = '';
+    arePasswordsMistmatch = true;
 
-  isnameFocused = false;
-  ispasswordFocused = false;
-  iscnfrmpasswordFocused = false;
-  isemailFocused = false;
+    /**
+   * Build the sign up form
+   */
+    @ViewChildren('signupForm') signupForm: QueryList<InputComponent>;
 
-  /**
+    /**
    * Login route path
    */
-  loginRoute = '/auth/login';
+    loginRoute = '/auth/login';
 
-  /**
+    /**
    * Signup route path
    */
-  signupRoute = '/auth/signup';
+    signupRoute = '/auth/signup';
 
-  /**
+    /**
    * Constructor.
    * @param document  window document Injection.
    * @param windowService  ActivatedRoute Injection.
@@ -50,99 +54,101 @@ export class SignupComponent implements OnInit, AfterViewInit {
    * @param route  ActivatedRoute Injection.
    * @param endpointsService
    */
-  constructor(@Inject(DOCUMENT) private document: Document,
-              private windowService: WindowService,
-              private globalService: GlobalService,
-              private apiService: ApiService,
-              public authService: AuthService,
-              private route: ActivatedRoute,
-              private endpointsService: EndpointsService,
-              private router: Router) {
-  }
+    constructor(
+        @Inject(DOCUMENT) private document: Document,
+        private windowService: WindowService,
+        private globalService: GlobalService,
+        private apiService: ApiService,
+        public authService: AuthService,
+        private route: ActivatedRoute,
+        private endpointsService: EndpointsService,
+        private router: Router
+    ) { }
 
-  /**
+    /**
    * Component init function.
    */
-  ngOnInit() {
-  }
+    ngOnInit() { }
 
-  /**
+    /**
    * Component after view initialized.
    */
-  ngAfterViewInit() {
-  }
+    ngAfterViewInit() { }
 
-  // Function to signup
-  userSignUp(signupFormValid) {
-    if (signupFormValid) {
-      this.globalService.startLoader('Setting up your details!');
-      const SIGNUP_BODY = JSON.stringify({
-        username: this.authService.regUser['name'],
-        email: this.authService.regUser['email'],
-        password1: this.authService.regUser['password'],
-        password2: this.authService.regUser['confirm_password']
-      });
-
-      this.apiService.postUrl(this.endpointsService.signupURL(), SIGNUP_BODY).subscribe(
-        data => {
-
-          if (data.status === 201) {
-            this.authService.isFormError = false;
-            this.authService.regMsg = 'Registered successfully, Login to continue!';
-          }
-
-          // Success Message in data.message
-          setTimeout(() => {
-            this.globalService.showToast('success', 'Registered successfully. Please verify your email address!', 5);
-          }, 1000);
-
-          this.router.navigate([this.loginRoute]);
-          this.globalService.stopLoader();
-        },
-
-        err => {
-          this.globalService.stopLoader();
-          if (err.status === 400) {
-            this.authService.isFormError = true;
-            let non_field_errors, isUsername_valid, isEmail_valid, isPassword1_valid, isPassword2_valid;
-            try {
-              non_field_errors = typeof (err.error.non_field_errors) !== 'undefined';
-              isUsername_valid = typeof (err.error.username) !== 'undefined';
-              isEmail_valid = typeof (err.error.email) !== 'undefined';
-              isPassword1_valid = typeof (err.error.password1) !== 'undefined';
-              isPassword2_valid = typeof (err.error.password2) !== 'undefined';
-              if (non_field_errors) {
-                this.authService.FormError = err.error.non_field_errors[0];
-              } else if (isUsername_valid) {
-                this.authService.FormError = err.error.username[0];
-              } else if (isEmail_valid) {
-                this.authService.FormError = err.error.email[0];
-              } else if (isPassword1_valid) {
-                this.authService.FormError = err.error.password1[0];
-              } else if (isPassword2_valid) {
-                this.authService.FormError = err.error.password2[0];
-              }
-
-            } catch (error) {
-              setTimeout(() => {
-                this.globalService.showToast('Error', 'Registration UnSuccessful.Please Try Again!', 5);
-              }, 1000);
-            }
-          } else {
-            this.globalService.handleApiError(err);
-          }
-        },
-
-        () => {}
-      );
+    formValidate() {
+        this.globalService.formValidate(this.signupForm, this.userSignUp, this);
     }
-  }
 
+    // Function to signup
+    userSignUp(self) {
+        self.globalService.startLoader('Setting up your details!');
+        const password1 = self.globalService.formValueForLabel(self.signupForm, 'password');
+        const password2 = self.globalService.formValueForLabel(self.signupForm, 'confirm_password');
 
-// function to check password strength
-  checkStrength(password) {
-    const passwordStrength = this.authService.passwordStrength(password);
-    this.message = passwordStrength[0];
-    this.color = passwordStrength[1];
-  }
+        const SIGNUP_BODY = JSON.stringify({
+            username: self.globalService.formValueForLabel(self.signupForm, 'name'),
+            email: self.globalService.formValueForLabel(self.signupForm, 'email'),
+            password1,
+            password2
+        });
+        self.apiService.postUrl(self.endpointsService.signupURL(), SIGNUP_BODY).subscribe(
+            (data) => {
+                if (data.status === 201) {
+                    self.authService.isFormError = false;
+                    self.authService.regMsg = 'Registered successfully, Login to continue!';
+                }
+
+                // Success Message in data.message
+                setTimeout(() => {
+                    self.globalService.showToast(
+                        'success',
+                        'Registered successfully. Please verify your email address!',
+                        5
+                    );
+                }, 1000);
+
+                self.router.navigate([self.loginRoute]);
+                self.globalService.stopLoader();
+            },
+            (err) => {
+                self.globalService.stopLoader();
+                if (err.status === 400) {
+                    self.authService.isFormError = true;
+                    let non_field_errors, isUsername_valid, isEmail_valid, isPassword1_valid, isPassword2_valid;
+                    try {
+                        non_field_errors = typeof err.error.non_field_errors !== 'undefined';
+                        isUsername_valid = typeof err.error.username !== 'undefined';
+                        isEmail_valid = typeof err.error.email !== 'undefined';
+                        isPassword1_valid = typeof err.error.password1 !== 'undefined';
+                        isPassword2_valid = typeof err.error.password2 !== 'undefined';
+                        if (non_field_errors) {
+                            self.authService.FormError = err.error.non_field_errors[0];
+                        } else if (isUsername_valid) {
+                            self.authService.FormError = err.error.username[0];
+                        } else if (isEmail_valid) {
+                            self.authService.FormError = err.error.email[0];
+                        } else if (isPassword1_valid) {
+                            self.authService.FormError = err.error.password1[0];
+                        } else if (isPassword2_valid) {
+                            self.authService.FormError = err.error.password2[0];
+                        }
+                    } catch (error) {
+                        setTimeout(() => {
+                            self.globalService.showToast('Error', 'Registration UnSuccessful.Please Try Again!', 5);
+                        }, 1000);
+                    }
+                } else {
+                    self.globalService.handleApiError(err);
+                }
+            },
+            () => { }
+        );
+    }
+
+    // function to check password strength
+    checkStrength(password) {
+        const passwordStrength = this.authService.passwordStrength(password);
+        this.message = passwordStrength[0];
+        this.color = passwordStrength[1];
+    }
 }

--- a/src/app/components/utility/input/input.component.html
+++ b/src/app/components/utility/input/input.component.html
@@ -1,19 +1,34 @@
 <div class="input-group">
-  <div *ngIf="type!='file' && type!='textarea' && type!='datetime'">
-    <input class="input-field" (input)="validateInput($event.target.value)"
-      [class.isValid]="isValid" [class.theme-dark]="theme=='dark'"
-      name="{{name}}" type="{{type}}" [value]="value" [readonly]="isReadonly">
+  <div *ngIf="type!='file' && type!='textarea' && type!='datetime' && type!='password'">
+    <input class="input-field" (input)="validateInput($event.target.value)" (focusin)="isFocus = true"
+      (focusout)="isFocus = false" [class.isValid]="isValid" [class.theme-dark]="theme=='dark'" name="{{name}}"
+      type="{{type}}" class="{{inputStyle}}" [value]="value" [readonly]="isReadonly">
     <span class="input-bar"></span>
     <label [class.is-not-empty]="!isEmpty" [class.theme-dark]="theme=='dark'">{{placeholder}}</label>
-    <i class="input-icon {{icon}}" *ngIf="isIconPresent"></i>
-    <div class="input-message" #textValue [class.hidden]="toggleErrorMessage()">{{message}}</div>
+    <i class="input-icon {{icon}}" [class.color-black]="isFocus" *ngIf="isIconPresent"></i>
+    <div class="input-message" #textValue [class.hidden]="toggleErrorMessage()">
+      <p>{{message}}</p>
+    </div>
+  </div>
+
+  <div *ngIf="type==='password'">
+    <input class="input-field" (input)="validateInput($event.target.value)" [class.isValid]="isValid"
+      (focusin)="isFocus = true" (focusout)="isFocus = false" [class.theme-dark]="theme=='dark'" name="{{name}}"
+      type="{{showPassword? 'text': 'password'}}" class="{{inputStyle}}" [value]="value" [readonly]="isReadonly">
+    <span class="input-bar"></span>
+    <label [class.is-not-empty]="!isEmpty" [class.theme-dark]="theme=='dark'">{{placeholder}}</label>
+    <span (click)="toggleShowPassword()">
+      <i *ngIf="!showPassword" class="input-icon fa fa-eye pointer" [class.color-black]="isFocus"></i>
+      <i *ngIf="showPassword" class="input-icon fa fa-eye-slash pointer" [class.color-black]="isFocus"></i>
+    </span>
+    <div class="input-message" #textValue [class.hidden]="toggleErrorMessage()">
+      <p>{{message}}</p>
+    </div>
   </div>
 
   <div *ngIf="type=='textarea'">
-    <textarea autosize class="input-field"
-      (input)="validateInput($event.target.value)" [class.isValid]="isValid"
-      [class.theme-dark]="theme=='dark'" [value]="value"
-      [readonly]="isReadonly"></textarea>
+    <textarea autosize class="input-field" (input)="validateInput($event.target.value)" [class.isValid]="isValid"
+      [class.theme-dark]="theme=='dark'" [value]="value" [readonly]="isReadonly"></textarea>
     <span class="input-bar"></span>
     <label [class.is-not-empty]="!isEmpty" [class.theme-dark]="theme=='dark'">{{placeholder}}</label>
     <i class="input-icon {{icon}}" *ngIf="isIconPresent"></i>
@@ -21,11 +36,9 @@
   </div>
 
   <div *ngIf="type=='datetime'">
-    <input class="input-field" [(ngModel)]="value" [min]="mindatetime"
-      [owlDateTime]="datetime" [owlDateTimeTrigger]="datetime"
-      (input)="validateInput($event.target.value)" [class.isValid]="isValid"
-      [class.theme-dark]="theme=='dark'" type="{{type}}"
-      [readonly]="isReadonly">
+    <input class="input-field" [(ngModel)]="value" [min]="mindatetime" [owlDateTime]="datetime"
+      [owlDateTimeTrigger]="datetime" (input)="validateInput($event.target.value)" [class.isValid]="isValid"
+      [class.theme-dark]="theme=='dark'" type="{{type}}" [readonly]="isReadonly">
     <owl-date-time [hour12Timer]="true" #datetime></owl-date-time>
     <span class="input-bar"></span>
     <label [class.is-not-empty]="!isEmpty" [class.theme-dark]="theme=='dark'">{{placeholder}}</label>
@@ -37,10 +50,8 @@
     <div class="btn btn-waves-effect ev-file-btn-dark waves-dark grad-btn
       grad-btn-transparent fs-14">
       <span> Upload File </span>
-      <input name="fileUpload" id="file-upload-custom" [(ngModel)]="fileValue"
-        accept="{{accept}}"
-        (change)="handleFileInput($event.target.files)" type="file"
-        class="text-dark-black" [readonly]="isReadonly" />
+      <input name="fileUpload" id="file-upload-custom" [(ngModel)]="fileValue" accept="{{accept}}"
+        (change)="handleFileInput($event.target.files)" type="file" class="text-dark-black" [readonly]="isReadonly" />
     </div>
     <div class="file-path-wrapper">
       <input type="text" value="{{placeholder}}" disabled>

--- a/src/app/components/utility/input/input.component.scss
+++ b/src/app/components/utility/input/input.component.scss
@@ -175,7 +175,7 @@
     text-align: left;
     margin-top: 10px;
     font-size: 12px;
-    font-weight: $fw-light;
+    font-weight: $fw-regular;
     color: $yellow;
     &.hidden {
       opacity: 0;

--- a/src/app/components/utility/input/input.component.ts
+++ b/src/app/components/utility/input/input.component.ts
@@ -88,6 +88,12 @@ export class InputComponent implements OnInit {
   @Input() editPhaseDetails: boolean;
 
   /**
+   * Class that style the input
+   */
+  @Input() inputStyle = '';
+
+
+  /**
    * Is email flag
    */
   isEmail = false;
@@ -128,6 +134,16 @@ export class InputComponent implements OnInit {
   fileSelected = null;
 
   /**
+   * Show password toggle
+   */
+  showPassword = false;
+
+  /**
+   * Is the input field focused
+   */
+  isFocus = false;
+
+  /**
    * Input field message for required fields
    */
   requiredMessage = 'Required field';
@@ -137,7 +153,7 @@ export class InputComponent implements OnInit {
    * @param document  Window document Injection.
    * @param globalService  GlobalService Injection.
    */
-  constructor(@Inject(DOCUMENT) private document: Document, private globalService: GlobalService) {  }
+  constructor(@Inject(DOCUMENT) private document: Document, private globalService: GlobalService) { }
 
   /**
    * Component on intialized
@@ -199,24 +215,25 @@ export class InputComponent implements OnInit {
     if (e === '' && this.isRequired) {
       this.isValid = false;
       this.isRequired ? this.message = this.requiredMessage : this.message = '';
+      return; // This is to no continue validating because the string is empty
     }
     if (this.isValidateCustom) {
-       this.isValid = this.validate(e).is_valid;
-       this.isValid ? this.message = '' : this.message = this.validate(e).message;
+      this.isValid = this.validate(e).is_valid;
+      this.isValid ? this.message = '' : this.message = this.validate(e).message;
     } else if (this.isEmail) {
-       this.isValid = this.globalService.validateEmail(e);
-       this.isValid ? this.message = '' : this.message = 'Enter a valid email';
+      this.isValid = this.globalService.validateEmail(e);
+      this.isValid ? this.message = '' : this.message = 'Enter a valid email';
     } else if (this.type === 'text' || this.type === 'textarea') {
-       this.isValid = this.globalService.validateText(e);
-       this.isValid ? this.message = '' : this.message = 'Enter a valid text';
+      this.isValid = this.globalService.validateText(e);
+      this.isValid ? this.message = '' : this.message = 'Enter a valid text';
     } else if (this.type === 'number') {
       this.isValid = this.globalService.validateInteger(e);
       this.isValid ? this.message = '' : this.message = 'Enter a valid number';
     } else if (this.type === 'datetime') {
       this.isValid = true;
     } else if (this.type === 'password') {
-       this.isValid = this.globalService.validatePassword(e);
-       this.isValid ? this.message = '' : this.message = 'Password minimum 8 characters';
+      this.isValid = this.globalService.validatePassword(e);
+      this.isValid ? this.message = '' : this.message = 'Password minimum 8 characters';
     }
     if (this.name === 'bannedEmailIds' || this.name === 'filterByTeamName') {
       this.message = '';
@@ -244,11 +261,15 @@ export class InputComponent implements OnInit {
     this.document.getElementById(id).click();
   }
 
-  showErrorCondition () {
+  showErrorCondition() {
     return (this.isRequired && this.isEmpty) || (!this.isValid && !this.isEmpty);
   }
 
-  toggleErrorMessage () {
+  toggleErrorMessage() {
     return !((this.showErrorCondition() || this.message !== '') && this.isDirty);
+  }
+
+  toggleShowPassword() {
+    return this.showPassword = !this.showPassword;
   }
 }

--- a/src/app/components/utility/input/input.component.ts
+++ b/src/app/components/utility/input/input.component.ts
@@ -92,6 +92,11 @@ export class InputComponent implements OnInit {
    */
   @Input() inputStyle = '';
 
+  /**
+   * Another input component needed to
+   * crossfield validation
+   */
+  @Input() fieldToCompare: string;
 
   /**
    * Is email flag
@@ -218,7 +223,7 @@ export class InputComponent implements OnInit {
       return; // This is to no continue validating because the string is empty
     }
     if (this.isValidateCustom) {
-      this.isValid = this.validate(e).is_valid;
+      this.isValid = this.validate(e, this.fieldToCompare).is_valid;
       this.isValid ? this.message = '' : this.message = this.validate(e).message;
     } else if (this.isEmail) {
       this.isValid = this.globalService.validateEmail(e);

--- a/src/app/services/global.service.ts
+++ b/src/app/services/global.service.ts
@@ -171,7 +171,7 @@ export class GlobalService {
   showConfirm(params) {
     if (!this.isConfirming) {
       this.isConfirming = true;
-      const TEMP = { isConfirming: true};
+      const TEMP = { isConfirming: true };
       this.confirmSource.next(Object.assign({}, params, TEMP));
     }
   }
@@ -182,7 +182,7 @@ export class GlobalService {
   hideConfirm() {
     if (this.isConfirming) {
       this.isConfirming = false;
-      const TEMP = { isConfirming: false};
+      const TEMP = { isConfirming: false };
       this.confirmSource.next(Object.assign({}, this.modalDefault, TEMP));
     }
   }
@@ -194,7 +194,7 @@ export class GlobalService {
   showModal(params) {
     if (!this.isModalVisible) {
       this.isModalVisible = true;
-      const TEMP = { isModalVisible: true};
+      const TEMP = { isModalVisible: true };
       this.modalSource.next(Object.assign({}, params, TEMP));
     }
   }
@@ -206,7 +206,7 @@ export class GlobalService {
   showEditPhaseModal(params) {
     if (!this.isEditPhaseModalVisible) {
       this.isEditPhaseModalVisible = true;
-      const TEMP = { isEditPhaseModalVisible: true};
+      const TEMP = { isEditPhaseModalVisible: true };
       this.editPhasemodalSource.next(Object.assign({}, params, TEMP));
     }
   }
@@ -218,7 +218,7 @@ export class GlobalService {
   showTermsAndConditionsModal(params) {
     if (!this.isTermsAndConditionsModalVisible) {
       this.isTermsAndConditionsModalVisible = true;
-      const TEMP = { isTermsAndConditionsModalVisible: true};
+      const TEMP = { isTermsAndConditionsModalVisible: true };
       this.termsAndConditionsSource.next(Object.assign({}, params, TEMP));
     }
   }
@@ -229,7 +229,7 @@ export class GlobalService {
   hideModal() {
     if (this.isModalVisible) {
       this.isModalVisible = false;
-      const TEMP = { isModalVisible: false};
+      const TEMP = { isModalVisible: false };
       this.modalSource.next(Object.assign({}, this.modalDefault, TEMP));
     }
   }
@@ -240,7 +240,7 @@ export class GlobalService {
   hideEditPhaseModal() {
     if (this.isEditPhaseModalVisible) {
       this.isEditPhaseModalVisible = false;
-      const TEMP = { isEditPhaseModalVisible: false};
+      const TEMP = { isEditPhaseModalVisible: false };
       this.editPhasemodalSource.next(Object.assign({}, this.editPhaseModalDefault, TEMP));
     }
   }
@@ -251,7 +251,7 @@ export class GlobalService {
   hideTermsAndConditionsModal() {
     if (this.isTermsAndConditionsModalVisible) {
       this.isTermsAndConditionsModalVisible = false;
-      const TEMP = { isTermsAndConditionsModalVisible: false};
+      const TEMP = { isTermsAndConditionsModalVisible: false };
       this.termsAndConditionsSource.next(Object.assign({}, this.termsAndConditionsModalDefault, TEMP));
     }
   }
@@ -286,7 +286,7 @@ export class GlobalService {
       }
     });
     if (!requiredFieldMissing) {
-       callback(self);
+      callback(self);
     }
   }
 
@@ -392,7 +392,7 @@ export class GlobalService {
   checkTokenValidity(err, toast = true) {
     if (err.error !== null && typeof err.error === 'object' && err.error['detail']) {
       if (err.error['detail'].indexOf('Invalid token') !== -1 ||
-          err.error['detail'].indexOf('Token has expired') !== -1) {
+        err.error['detail'].indexOf('Token has expired') !== -1) {
         this.triggerLogout();
         this.showToast('error', 'Token Invalid! Please Login again.', 5);
       }
@@ -521,10 +521,10 @@ export class GlobalService {
    * @returns boolean indicating valid/invalid email
    */
   validateEmail(email) {
-    const RE = new RegExp (['^(([^<>()[\\]\\\.,;:\\s@\"]+(\\.[^<>()\\[\\]\\\.,;:\\s@\"]+)*)',
-                        '|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.',
-                        '[0-9]{1,3}\])|(([a-zA-Z\\-0-9]+\\.)+',
-                        '[a-zA-Z]{2,}))$'].join(''));
+    const RE = new RegExp(['^(([^<>()[\\]\\\.,;:\\s@\"]+(\\.[^<>()\\[\\]\\\.,;:\\s@\"]+)*)',
+      '|(".+"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.',
+      '[0-9]{1,3}\])|(([a-zA-Z\\-0-9]+\\.)+',
+      '[a-zA-Z]{2,}))$'].join(''));
     return RE.test(email);
   }
 
@@ -559,6 +559,20 @@ export class GlobalService {
       return true;
     }
     return false;
+  }
+
+  /**
+     * Custom validator to check equality of the password fields
+     * @param password1 The confirm password field
+     * @param password2 The password field
+     * @return returns an object that contain a message and a boolean
+     */
+  validateTwoPassword(password1: string, password2: string) {
+    const is_valid = password1 === password2;
+    return {
+      is_valid,
+      message: !is_valid ? 'Passwords do not match' : ''
+    };
   }
 
   /**

--- a/src/app/services/global.service.ts
+++ b/src/app/services/global.service.ts
@@ -562,20 +562,6 @@ export class GlobalService {
   }
 
   /**
-     * Custom validator to check equality of the password fields
-     * @param password1 The confirm password field
-     * @param password2 The password field
-     * @return returns an object that contain a message and a boolean
-     */
-  validateTwoPassword(password1: string, password2: string) {
-    const is_valid = password1 === password2;
-    return {
-      is_valid,
-      message: !is_valid ? 'Passwords do not match' : ''
-    };
-  }
-
-  /**
    * Start loader message
    * @param msg  string
    */

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -2047,6 +2047,12 @@ input[type="radio"].selectTeam + label {
   border: 2px solid #252833;
 }
 
+/* input box margins */
+.input-field input[type=text],
+.input-field input[type=password] {
+  margin-bottom: 0 !important;
+}
+
 /* label focus color */
 
 .input-field input[type=email]:focus+label,
@@ -2190,7 +2196,7 @@ tr {
 }
 
 .color-black {
-  color: black;
+  color: black !important;
 }
 
 .analytics-challenge-single-line {


### PR DESCRIPTION
<!--
(Thanks for sending a pull request! .)
-->

<!--The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor." -->

<!-- Add issue number here. If you do not solve the issue entirely, please change the message e.g. "Addresses #IssueNumber -->
Fixes #190  Replace template driven form in reset-password-confirm page with app input component

#### Changes proposed in this pull request:

<!-- Changes: Add here what changes were made in this issue and if possible provide links. -->
- Change the template driven form in the Login Page
- Change the template driven form in the reset-password page
- Change the template driven form in the Sign Up page

<!-- Demo Link: Add here the link where you changes can be seen. -->
- Link to live demo: http://pr-190-evalai.surge.sh <!-- Replace XXX with your PR no: -->
