### PR TITLE
Inconsistency in the tabs shown to host and participants

### DIFF
--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -181,7 +181,7 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
     });
     this.challengeService.currentParticipationStatus.subscribe(status => {
       this.isParticipated = status;
-      if (!status) {
+      if (status) {
         this.globalService.storeData(this.globalService.redirectStorageKey, {path: this.routerPublic.url});
         let redirectToPath = '';
         if (this.router.url.split('/').length === 4) {

--- a/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
+++ b/src/app/components/challenge/challengeviewallsubmissions/challengeviewallsubmissions.component.ts
@@ -181,7 +181,7 @@ export class ChallengeviewallsubmissionsComponent implements OnInit, AfterViewIn
     });
     this.challengeService.currentParticipationStatus.subscribe(status => {
       this.isParticipated = status;
-      if (status) {
+      if (!status) {
         this.globalService.storeData(this.globalService.redirectStorageKey, {path: this.routerPublic.url});
         let redirectToPath = '';
         if (this.router.url.split('/').length === 4) {

--- a/src/app/services/challenge.service.ts
+++ b/src/app/services/challenge.service.ts
@@ -135,6 +135,7 @@ export class ChallengeService {
     });
     SELF.fetchPhases(id);
     SELF.fetchPhaseSplits(id);
+    SELF.changeChallengeHostStatus(false);
     this.apiService.getUrl(API_PATH).subscribe(
       data => {
         if (data['id'] === parseInt(id, 10)) {


### PR DESCRIPTION
Bug Fix [Inconsistency in the tabs shown to host and participants]

**Bug description**
The `view_all_submission` tab along with `close participation` button is visible to any normal user which should only be visible to the host of that challenge.

GIF of issue:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/44888949/83324479-20078280-a283-11ea-9308-46579546fa07.gif)

GIF after Fix:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/44888949/83324483-24cc3680-a283-11ea-93ac-c1b2620729fc.gif)
