### PR TITLE
Fixed remove feature for Banned Email Ids

### DIFF
--- a/src/app/components/challenge/challengesettings/challengesettings.component.ts
+++ b/src/app/components/challenge/challengesettings/challengesettings.component.ts
@@ -105,11 +105,14 @@ export class ChallengesettingsComponent implements OnInit {
    */
   remove(email): void {
     const SELF = this;
-    const index = this.bannedEmailIds.indexOf(email);
+    const index = SELF.bannedEmailIds.indexOf(email);
 
     if (index >= 0) {
-      this.bannedEmailIds.splice(index, 1);
+      SELF.bannedEmailIds.splice(index, 1);
     }
+
+    // updating the banned Email Ids list
+    SELF.updateBannedEmailList();
   }
 
   validateEmail(email) {


### PR DESCRIPTION
Fixes: #309 [Remove Banned Email Id button not working]

Changes proposed in this pull request:

- Remove button works as expected.

GIF:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/44888949/78701870-5a107400-7925-11ea-8e2e-a84d7a60c6a8.gif)

