### PR TITLE
Add dpkg package to update chrome version to match chrome driver version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 dist: trusty
 language: node_js
 addons:
+  apt:
+    packages:
+      - dpkg
   chrome: stable
 
 node_js:


### PR DESCRIPTION
**Issue:**

Travis build failing due to mismatching of chrome and chrome driver versions, it was not able to download the latest debain package as it is missing the debian package manager.

**Fix:**

Added the `dpkg` package in `travis.yml`